### PR TITLE
add LIMIT 1000 to event reg URL

### DIFF
--- a/srv/routes/khorosUser.js
+++ b/srv/routes/khorosUser.js
@@ -312,7 +312,7 @@ module.exports = (app) => {
                     <a
                         target="_blank"
                         rel="noreferrer"
-                        href="${encodeURI("https://groups.community.sap.com/api/2.0/search?q=SELECT id, user.login, user.email, user.first_name, user.last_name, rsvp_response, user.sso_id FROM rsvps WHERE rsvp_response = 'yes' and message.id = '" + item.id + "'")}">
+                        href="${encodeURI("https://groups.community.sap.com/api/2.0/search?q=SELECT id, user.login, user.email, user.first_name, user.last_name, rsvp_response, user.sso_id FROM rsvps WHERE rsvp_response = 'yes' and message.id = '" + item.id + "' LIMIT 1000")}">
                         <button>
                             Open event registrations in new tab
                         </button></a>


### PR DESCRIPTION
While the CodeJam events have relatively small numbers of attendees, we might want to quickly use this facility to get this data for other events (see e.g. [this conversation](https://sap-dev-com-relations.slack.com/archives/C016PVCDWEN/p1695104898445519?thread_ts=1695104578.612869&cid=C016PVCDWEN)).
