### PR TITLE
fix: badge name

### DIFF
--- a/srv/util/badges.json
+++ b/srv/util/badges.json
@@ -946,7 +946,7 @@
         "Week": "Week 4"
     },
     {
-        "displayName": "#2C210B - Devtoberfest 2024 - MAD (ML, AI & Data), Validation Tutorial Jump Start Session on Generative AI Hub - Oct. 24",
+        "displayName": "#2C210B - Devtoberfest 2024 - MAD (ML, AI & Data), Validation Tutorial Jump Start Session on Genertive AI Hub - Oct. 24",
         "points": 600,
         "URL": "https://developers.sap.com/tutorials/devtoberfest2024-week4-ai-jump-start-validation-genai.html",
         "Date": "2024-10-24",


### PR DESCRIPTION
There is a typo in the displayName of the Badge on the SAP Community.
Better to fix it here would be in the SAP Community :)