### PR TITLE
Bind deploy job to production environment (OSPO)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `environment: production` to the `deploy` job in `.github/workflows/deploy.yml` so the workflow resolves `CF_*` secrets from the environment scope and is gated by environment protection rules.
- Companion to GitHub-side configuration (already applied):
  - `production` environment created with `protected_branches: true` and required reviewer (`jung-thomas`)
  - Branch ruleset `main-protection` on `main`: blocks deletion + force-push, requires PR with 1 approval and thread resolution, requires `ci` status check, dismisses stale approvals on new pushes
- Addresses OSPO requirements:
  - Main/release branches protected with branch protection ruleset
  - Secrets and publishing workflows protected by GitHub Environment

## Cutover notes
1. After merge, populate the env-scoped secrets:
   \`\`\`
   gh secret set CF_API      --env production
   gh secret set CF_USERNAME --env production
   gh secret set CF_PASSWORD --env production
   gh secret set CF_ORG      --env production
   gh secret set CF_SPACE    --env production
   \`\`\`
2. Run the **Deploy to Cloud Foundry** workflow once against \`main\`; approve the deployment when prompted.
3. Once that run succeeds, delete the now-redundant repo-level copies:
   \`\`\`
   for s in CF_API CF_USERNAME CF_PASSWORD CF_ORG CF_SPACE; do gh secret delete \$s; done
   \`\`\`

## Test plan
- [ ] CI workflow passes on this PR
- [ ] After merge, env secrets set
- [ ] Manual \`workflow_dispatch\` of Deploy succeeds end-to-end with the new approval gate
- [ ] Repo-level CF_* secrets deleted