### PR TITLE
fix: route Khoros user API calls via messages.author.* expansion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Requires Node.js `^22.0.0 || ^24.0.0`.
 
 - **`srv/util/`** — Shared utilities:
   - `svgRender.js` — SVG building blocks (headers, styles, shapes, image embedding)
-  - `khoros.js` — SAP Community Khoros API calls (`https://community.sap.com/khhcw49343/api/2.0/users/:scnId`), file-based caching of API responses (1 day TTL via runtime-generated `tags.json`)
+  - `khoros.js` — SAP Community Khoros API calls. Direct user lookup (`/khhcw49343/api/2.0/users/:scnId`) was deprecated for anonymous callers in mid-2026 (returns HTTP 404 / code 303). `callUserAPI` now queries `…/api/2.0/search?q=SELECT author.* FROM messages WHERE author.id='<scnId>' LIMIT 1` and re-shapes the result to the legacy `{ data: <user> }` envelope so callers are unchanged. Falls back to `author.login` lookup with dot→underscore login normalization. File-based caching of API responses (1 day TTL via runtime-generated `tags.json`).
   - `error.js` — Error handler that renders errors as SVG/PNG images
   - `texts.js` — i18n via `@sap/textbundle`, reads `Accept-Language` header
   - `badges.json`, `badges2024.json` — Badge definitions (id, name, image URL)

--- a/mta.yaml
+++ b/mta.yaml
@@ -1,6 +1,6 @@
 _schema-version: "3.3"
 ID: scn-badges
-version: 5.4.0
+version: 5.4.1
 modules:
   - name: scn-badges-srv
     type: nodejs

--- a/srv/doc/developer-guide.md
+++ b/srv/doc/developer-guide.md
@@ -283,14 +283,26 @@ The codebase uses two different Khoros API hosts for different purposes:
 
 | Host | API Version | Used For |
 |---|---|---|
-| `community.sap.com/khhcw49343/api/2.0/` | v2 REST | User profile with badge list (`/users/:id`) |
+| `community.sap.com/khhcw49343/api/2.0/` | v2 REST + Search | User profile with badge list — via `search` over `messages.author.*` (direct `/users/:id` was deprecated for anonymous callers in mid-2026) |
 | `groups.community.sap.com/api/2.0/` | v2 REST + Search | Events, RSVPs, boards, threads, member queries |
 
 ### User Profile API (`util/khoros.js`)
 
-**Endpoint:** `GET https://community.sap.com/khhcw49343/api/2.0/users/{scnId}`
+**Effective endpoint:** `GET https://community.sap.com/khhcw49343/api/2.0/search?q=SELECT ... FROM messages WHERE author.id = '{scnId}' LIMIT 1`
 
-The `scnId` can be either the numeric community ID or the string login name. The response is a Khoros standard user object. Key fields used:
+> **Why search and not `/users/:id`?** As of mid-2026 the SAP Community revoked anonymous read permission on the `users` collection (`allow_restapi_call_read`), so direct `GET /users/{scnId}` returns HTTP 404 ("The user was not found", code 303). The same data is still reachable through field expansion on a `messages` query, because the `messages` collection retains anonymous read. `callUserAPI` queries the search endpoint, projects the needed `author.*` fields, and re-shapes the result to the legacy `{ data: <user> }` envelope so callers stay unchanged.
+
+**Lookup strategy:** `callUserAPI(scnId)` tries up to three queries in order, returning the first non-empty result:
+
+1. If `scnId` is all digits → `WHERE author.id = '<scnId>'`
+2. Else (login form) → `WHERE author.login = '<scnId-with-dots-replaced-by-underscores>'`
+3. If still empty and the original differed from the normalized form → retry with the original (dotted) login
+
+The dot-to-underscore normalization handles the migration where logins like `thomas.jung` were renamed to `thomas_jung`.
+
+**Caveat:** A user is reachable only if they have authored at least one message. Pure read-only profiles (zero posts) return `null` and `callUserAPI` throws `"No messages found for user '<scnId>' — user may have zero posts or the ID/login is unknown"`.
+
+The `scnId` can be either the numeric community ID or the string login name. The response is re-shaped to look like a Khoros user object. Key fields used:
 
 ```
 data.login                      → fallback display name

--- a/srv/package-lock.json
+++ b/srv/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scn-badges-srv",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cloudnative/health-connect": "^2.1.0",
-        "@inquirer/search": "^4.1.8",
+        "@inquirer/search": "4.2.1",
         "@sap/logging": "^9.2.1",
         "@sap/textbundle": "^6.2.0",
         "accept-language-parser": "latest",
@@ -20,7 +20,7 @@
         "event-loop-lag": "1.4.0",
         "express": "5.2.1",
         "glob": "13.0.6",
-        "got": "^15.0.3",
+        "got": "15.0.5",
         "lodash": "^4.18.1",
         "marked": "^16.4.0",
         "multer": "^2.1.1",
@@ -30,7 +30,7 @@
         "overload-protection": "^1.2.3",
         "serve-favicon": "^2.5.1",
         "sharp": "^0.34.5",
-        "swagger-jsdoc": "^6.2.8",
+        "swagger-jsdoc": "6.3.0",
         "swagger-ui-express": "^5.0.1",
         "text-wrapper": "^2.0.2",
         "then-request": "^6.0.2",
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.2.1",
+        "eslint": "10.4.1",
         "nodemon": "^3.1.14",
         "typescript": "^6.0.3"
       },
@@ -48,15 +48,19 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
+        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -75,21 +79,57 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
       }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@cloudnative/health": {
       "version": "2.1.2",
@@ -176,9 +216,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -233,9 +273,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -778,30 +818,30 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
-      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
-      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
         "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -813,26 +853,26 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
-      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.8.tgz",
-      "integrity": "sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.9",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -844,12 +884,12 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -860,11 +900,14 @@
         }
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
@@ -1345,22 +1388,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -1443,7 +1470,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1638,18 +1664,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1862,7 +1888,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1894,10 +1919,26 @@
         "fast-string-truncated-width": "^3.0.2"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -1988,6 +2029,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
@@ -2043,12 +2100,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2170,9 +2221,9 @@
       }
     },
     "node_modules/got": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.0.3.tgz",
-      "integrity": "sha512-630of5aMTYM6g6epok5nuqvctP8InJISvt39iNt7y0r27rcGCdiPv9Cc6EbwfnkyT1g/shBoVhvDjtXZUbn/Rw==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.0.5.tgz",
+      "integrity": "sha512-PMIMaZuYUCK43+Z9JWEXea4kkX2b3301m81D5TS6QpfG4PmNyirzEdO/Oa2OHAN4GsjnPfvWCWsshKN2rq4/gQ==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^8.0.0",
@@ -2419,17 +2470,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2519,13 +2559,37 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2599,20 +2663,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
@@ -3054,6 +3104,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -3078,20 +3134,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3192,9 +3238,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3280,6 +3326,15 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-alpn": {
@@ -3493,7 +3548,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3506,7 +3560,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3649,39 +3702,23 @@
       }
     },
     "node_modules/swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
       "license": "MIT",
       "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "commander": "6.2.0",
         "doctrine": "3.0.0",
-        "glob": "7.1.6",
+        "glob": "11.1.0",
         "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
         "yaml": "2.0.0-1"
       },
       "bin": {
         "swagger-jsdoc": "bin/swagger-jsdoc.js"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/swagger-jsdoc/node_modules/commander": {
@@ -3694,48 +3731,27 @@
       }
     },
     "node_modules/swagger-jsdoc/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/swagger-ui-dist": {
@@ -4030,15 +4046,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/validator": {
-      "version": "13.15.35",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
-      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4052,7 +4059,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4127,26 +4133,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
       }
     }
   }

--- a/srv/package.json
+++ b/srv/package.json
@@ -1,13 +1,13 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "SCN Badges Service Layer",
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "dependencies": {
     "@cloudnative/health-connect": "^2.1.0",
-    "@inquirer/search": "^4.1.8",
+    "@inquirer/search": "^4.2.1",
     "@sap/logging": "^9.2.1",
     "@sap/textbundle": "^6.2.0",
     "accept-language-parser": "latest",
@@ -17,8 +17,9 @@
     "event-loop-lag": "1.4.0",
     "express": "5.2.1",
     "glob": "13.0.6",
-    "got": "^15.0.3",
+    "got": "^15.0.5",
     "lodash": "^4.18.1",
+    "marked": "^16.4.0",
     "multer": "^2.1.1",
     "mustache": "^4.2.0",
     "nocache": "^4.0.0",
@@ -26,8 +27,7 @@
     "overload-protection": "^1.2.3",
     "serve-favicon": "^2.5.1",
     "sharp": "^0.34.5",
-    "marked": "^16.4.0",
-    "swagger-jsdoc": "^6.2.8",
+    "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
     "text-wrapper": "^2.0.2",
     "then-request": "^6.0.2",
@@ -49,7 +49,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.2.1",
+    "eslint": "^10.4.1",
     "nodemon": "^3.1.14",
     "typescript": "^6.0.3"
   },

--- a/srv/smokeTestKhoros.mjs
+++ b/srv/smokeTestKhoros.mjs
@@ -1,0 +1,64 @@
+// Smoke test for srv/util/khoros.js callUserAPI against the live Khoros API.
+// Exercises both the production-failing case (numeric SCN ID 139 = thomas_jung)
+// and a login-form lookup. Confirms the shape consumed by routes is intact:
+//   - data.login / data.first_name / data.last_name
+//   - data.metrics.posts / data.rank.name
+//   - data.user_badges.items[].badge.id|title|icon_url
+//   - data.user_badges.items[].earned_date
+//
+// Usage:  node srv/smokeTestKhoros.mjs
+// Exits non-zero on any assertion failure.
+
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const khoros = require('./util/khoros.js')
+
+let failures = 0
+function assert(cond, msg) {
+    if (cond) {
+        console.log(`  ok   ${msg}`)
+    } else {
+        console.error(`  FAIL ${msg}`)
+        failures++
+    }
+}
+
+async function runCase(label, scnId) {
+    console.log(`\n[${label}]  callUserAPI(${JSON.stringify(scnId)})`)
+    let result
+    try {
+        result = await khoros.callUserAPI(scnId)
+    } catch (e) {
+        console.error(`  THREW: ${e.message}`)
+        failures++
+        return
+    }
+
+    assert(result && typeof result === 'object', 'returns an object')
+    assert(result?.data && typeof result.data === 'object', 'has .data')
+    assert(typeof result?.data?.login === 'string' && result.data.login.length > 0, '.data.login is non-empty string')
+    assert(typeof result?.data?.first_name === 'string', '.data.first_name is string')
+    assert(typeof result?.data?.last_name === 'string', '.data.last_name is string')
+    assert(typeof result?.data?.metrics?.posts === 'number', '.data.metrics.posts is number')
+    assert(typeof result?.data?.rank?.name === 'string', '.data.rank.name is string')
+    assert(Array.isArray(result?.data?.user_badges?.items), '.data.user_badges.items is array')
+    assert((result?.data?.user_badges?.items?.length ?? 0) > 0, 'has at least one badge')
+
+    const firstBadge = result?.data?.user_badges?.items?.[0]
+    assert(typeof firstBadge?.badge?.id === 'string' || typeof firstBadge?.badge?.id === 'number', 'badge.id present')
+    assert(typeof firstBadge?.badge?.title === 'string' && firstBadge.badge.title.length > 0, 'badge.title non-empty')
+    assert(typeof firstBadge?.badge?.icon_url === 'string' && firstBadge.badge.icon_url.startsWith('http'), 'badge.icon_url is URL')
+    assert(typeof firstBadge?.earned_date === 'string' && firstBadge.earned_date.length > 0, 'badge.earned_date is string')
+
+    // handleUserName end-to-end check (used by every route for the title text)
+    const userName = khoros.handleUserName(scnId, result)
+    assert(typeof userName === 'string' && userName.length > 0 && userName !== String(scnId),
+        `handleUserName resolves to a real name (got: ${JSON.stringify(userName)})`)
+}
+
+await runCase('numeric scnId',   '139')
+await runCase('login scnId (underscored)', 'thomas_jung')
+await runCase('login scnId (legacy dotted form)', 'thomas.jung')
+
+console.log(`\n${failures === 0 ? 'ALL PASS' : `${failures} FAILURE(S)`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/srv/util/khoros.js
+++ b/srv/util/khoros.js
@@ -4,21 +4,77 @@ const path = require('path')
 const cacheFile = path.join(__dirname, 'util', 'tags.json')
 module.exports.cacheFile = cacheFile
 
+// Direct user lookups against this endpoint started returning HTTP 404 (code 303,
+// "The user was not found") around mid-2026 after SAP Community revoked
+// allow_restapi_call_read for the anonymous user. Kept exported for backward
+// compatibility — callUserAPI now goes through the messages.author.* expansion
+// at searchAPIURL (see below).
 const userAPIURL = 'https://community.sap.com/khhcw49343/api/2.0/users/'
-module.exports.userAPIURL
+module.exports.userAPIURL = userAPIURL
 
-async function callUserAPI(scnId) {
+const searchAPIURL = 'https://community.sap.com/khhcw49343/api/2.0/search'
+module.exports.searchAPIURL = searchAPIURL
+
+// Fields projected from messages.author.* — together they reconstruct the
+// shape the routes expect under scnItems.data.* (login, name, metrics, rank,
+// and user_badges.items[].badge.{id,title,icon_url,description} + earned_date).
+const AUTHOR_FIELDS = [
+    'author.id',
+    'author.login',
+    'author.first_name',
+    'author.last_name',
+    'author.rank.name',
+    'author.metrics.posts',
+    'author.user_badges.badge.id',
+    'author.user_badges.badge.title',
+    'author.user_badges.badge.icon_url',
+    'author.user_badges.badge.description',
+    'author.user_badges.earned_date'
+].join(',')
+
+async function searchAuthor(whereClause) {
     const request = require('then-request')
-    const urlBadges = `${userAPIURL}${scnId}`
-
-    try {
-      let itemsRes = await request('GET', encodeURI(urlBadges))
-    const scnItems = JSON.parse(itemsRes.getBody())
-    return scnItems
-    } catch (error) {
-      throw new Error(`Error fetching SCN data for ID ${scnId}: ${error.message}`, { cause: error })
+    const query = `SELECT ${AUTHOR_FIELDS} FROM messages WHERE ${whereClause} LIMIT 1`
+    const url = `${searchAPIURL}?q=${encodeURIComponent(query)}`
+    const res = await request('GET', url)
+    const body = JSON.parse(res.getBody())
+    if (body.status !== 'success') {
+        throw new Error(`Khoros search failed: ${body.message || JSON.stringify(body)}`)
     }
-    
+    return body?.data?.items?.[0]?.author || null
+}
+
+// Resolves a user via two strategies, in order:
+//   1. If scnId looks numeric → SELECT ... WHERE author.id = '<scnId>'
+//   2. Else / on miss          → SELECT ... WHERE author.login = '<normalized>'
+// where normalization replaces dots with underscores (the community migrated
+// dotted logins like "thomas.jung" to "thomas_jung").
+// Returned shape mirrors the legacy /users/:id response — { data: <author> } —
+// so callers (showcaseBadges, activityCounts, devtoberfest) remain unchanged.
+async function callUserAPI(scnId) {
+    try {
+        const id = String(scnId)
+        const isNumeric = /^\d+$/.test(id)
+        let author = null
+
+        if (isNumeric) {
+            author = await searchAuthor(`author.id = '${id}'`)
+        }
+        if (!author) {
+            const login = id.replace(/\./g, '_')
+            author = await searchAuthor(`author.login = '${login}'`)
+        }
+        if (!author && !isNumeric && id !== id.replace(/\./g, '_')) {
+            // last-ditch: try the original (dotted) form unchanged
+            author = await searchAuthor(`author.login = '${id}'`)
+        }
+        if (!author) {
+            throw new Error(`No messages found for user '${scnId}' — user may have zero posts or the ID/login is unknown`)
+        }
+        return { data: author }
+    } catch (error) {
+        throw new Error(`Error fetching SCN data for ID ${scnId}: ${error.message}`, { cause: error })
+    }
 }
 module.exports.callUserAPI = callUserAPI
 


### PR DESCRIPTION
## Why

Production-failing URL reported by users:
`https://devrel-tools-prod-scn-badges-srv.cfapps.eu10.hana.ondemand.com/showcaseBadgesGroups/139/1570/674/384/900/390/?png=true`

Renders the SVG error card with:
```
Error fetching SCN data for ID 139: Server responded to
https://community.sap.com/khhcw49343/api/2.0/users/139 with status code 404:
{"status":"error","message":"The user was not found",
 "data":{"type":"error_data","code":303, ...}}
```

No code change on our side. Root cause is server-side: the SAP Community revoked anonymous `allow_restapi_call_read` permission on the Khoros `users` collection (the legacy `/restapi/vc/users/id/:id` endpoint surfaces the actual error: `User -1 does not have the following permission(s) at khhcw49343: [ allow_restapi_call_read ]`). The dotted-login migration (`thomas.jung` → `thomas_jung`) appears to have run around the same time. Direct `GET /api/2.0/users/:id` and `SELECT FROM users` both return empty/404 for every user we tested. Public profile pages `/t5/user/viewprofilepage/user-id/:id` also now return 403.

## What

Rewrite `srv/util/khoros.js` `callUserAPI` to query the still-anonymous-readable `messages` collection and project `author.*` fields:

```sql
SELECT id, subject,
       author.id, author.login, author.first_name, author.last_name,
       author.rank.name, author.metrics.posts,
       author.user_badges.badge.id,
       author.user_badges.badge.title,
       author.user_badges.badge.icon_url,
       author.user_badges.badge.description,
       author.user_badges.earned_date
FROM messages
WHERE author.id = '<scnId>'
LIMIT 1
```

Result is unwrapped to `{ data: data.items[0].author }` so every consumer (`showcaseBadges*`, `activityCounts`, `devtoberfest`, `handleUserName`, etc.) is unchanged.

Fallback chain handles both ID styles and the login migration:
1. `author.id = '<scnId>'` if scnId is all digits
2. `author.login = '<scnId.replace(/\./g, '_')>'` (dotted → underscored)
3. `author.login = '<scnId>'` (original dotted, last resort)

## Caveat

A user is reachable only if they have authored ≥1 message. Read-only profiles with zero posts now throw `"No messages found for user '<scnId>' — user may have zero posts or the ID/login is unknown"`. Devtoberfest contestants always satisfy this. If a specific user reports a regression, check if they've ever posted.

## Verification

| Check | Result |
|---|---|
| `srv/smokeTestKhoros.mjs` (3 IDs × 14 assertions: numeric, underscored, dotted) | ALL PASS |
| `eslint .` (full project) | 0 problems |
| `npm audit` | 0 vulnerabilities |
| `/showcaseBadgesGroups/139/1570/674/384/900/390/?png=true` (the failing URL) | HTTP 200, 10,610-byte 500×48 PNG |
| `/activity/139` | HTTP 200, posts=11,514, rank="Developer Advocate" |
| `/devtoberfest/profile/139` | HTTP 200, points=76200, level=4, badges=882 |
| `/showcaseBadges/thomas.jung` (legacy dotted login) | HTTP 200, no error card |
| `/` (intro page, exercises `marked`) | HTTP 200, headings render |

## Bonus housekeeping (same release)

Minor/patch dep bumps + transitive vuln patch:
- `@inquirer/search` 4.1.8 → 4.2.1
- `eslint` 10.2.1 → 10.4.1
- `got` 15.0.3 → 15.0.5
- `swagger-jsdoc` 6.2.8 → 6.3.0
- `qs` 6.15.1 → 6.15.2 (transitive, fixes [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — moderate DoS)

Deferred (major bumps, want their own PR after changelog review):
- `ejs` 5 → 6 — also worth deciding whether to remove (orphaned `views/selfie*.ejs`, no first-party render call)
- `marked` 16 → 18 — single call site in `routes/intro.js`

## Files

- `srv/util/khoros.js` — the actual fix
- `srv/smokeTestKhoros.mjs` — new live-API regression smoke test
- `srv/doc/developer-guide.md`, `CLAUDE.md` — document the new lookup strategy
- `srv/package.json`, `srv/package-lock.json` — dep bumps
- `srv/package.json`, `mta.yaml` — version 5.4.0 → 5.4.1