### PR TITLE
fix: address remaining Khoros API permission revocation impacts (refs #21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Standalone ESM scripts at the `srv/` root for offline data management (not part 
 - `badgeCheck.mjs` — Verify badges for community members
 - `contest.mjs` — Process Devtoberfest contest data
 - `scavengerHunt.mjs` — Process scavenger hunt entries
-- `trees.mjs` — Process tree-planting initiative data
+- `trees.mjs` — Process tree-planting initiative data. Originally pulled badges from `https://people-api.services.sap.com/rs/badge/<scnId>`, but that endpoint returned HTTP 410 Gone in mid-2026; now sources `displayName`/`timestamp` pairs from `khoros.callUserAPI(scnId)` (mapping `badge.title` → `displayName`, `earned_date` → `timestamp`).
 
 Run with `node srv/<script>.mjs` from the repo root.
 

--- a/srv/doc/developer-guide.md
+++ b/srv/doc/developer-guide.md
@@ -229,7 +229,15 @@ Returns all upcoming events (start_time >= now) for a board, ordered by start ti
 JSON version of `eventRegs` — returns an array of `{ id, name, href, startTime, endTime, timezone, rsvpCount, location }`.
 
 #### `GET /khoros/members/:grouphub`
-Returns an HTML page containing a link to the Khoros Search API query for members of a group hub (`SELECT id, sso_id, login, email... WHERE node.id = 'grouphub:{name}'`). Limit 6000.
+
+Admin page for listing the members of a SAP Community grouphub. Renders an HTML page with two links:
+
+1. **Open in browser (logged in)** — the legacy `SELECT ... FROM users WHERE node.id = 'grouphub:<name>'` Khoros Search URL. Anonymous callers receive an empty result set since the mid-2026 permission revocation, but admins who are signed in to community.sap.com in the same browser session still get the full PII (email, sso_id, first/last name). This is the existing admin workflow and is preserved as-is.
+2. **View as JSON (anonymous)** — appends `?format=json` to the same URL. The route then runs the `messages.author.*` workaround (`khoros.searchGrouphubMembers`) and returns a deduped Khoros-style user-list envelope. Caveats:
+   - Only authors who have **posted** in the grouphub appear; lurkers are not surfaced.
+   - PII fields (`email`, `sso_id`) are redacted to empty strings by Khoros for anonymous callers and are not projected.
+   - `first_name` / `last_name` are populated only when the underlying user record exposes them publicly.
+   - The query paginates through messages in pages of 500 (Khoros 504s above ~6000) and stops on natural exhaustion, on a `maxMessages` ceiling of 5000, or after 3 consecutive saturated pages add no new authors. Response includes a `data._pagination` breadcrumb (`{ pages, messagesScanned, truncated, pageSize, maxMessages }`); if `truncated` is `true` the ceiling clipped a very active grouphub and `maxMessages` should be bumped.
 
 #### `GET /khoros/devtoberfestMembers`
 Returns the cached `members.json` fetched from GitHub (same data used by the gameboard).

--- a/srv/routes/khorosUser.js
+++ b/srv/routes/khorosUser.js
@@ -8,23 +8,76 @@ const texts = require("../util/texts")
 
 module.exports = (app) => {
 
+    /**
+     * @swagger
+     * /khoros/members/{grouphub}:
+     *   get:
+     *     summary: List members of a SAP Community grouphub
+     *     description: |
+     *       Returns an HTML admin page with two ways to view members:
+     *       1. A "Open in browser (logged in)" link that runs the legacy
+     *          `SELECT ... FROM users WHERE node.id = 'grouphub:<name>'`
+     *          search. Clicking this link in a browser that already has an
+     *          SAP Community login cookie returns full PII (email, sso_id,
+     *          first/last name) — that is the existing admin workflow.
+     *       2. A "View as JSON (anonymous)" link to `?format=json`, which
+     *          uses an anonymously-readable `messages.author.*` workaround.
+     *          PII fields (email, sso_id) are not available via this path —
+     *          Khoros redacts them at the response layer for unauthenticated
+     *          callers — but `id`, `login`, `view_href`, and `first/last_name`
+     *          (when public on the user record) are returned.
+     *
+     *       Adding `?format=json` returns option 2 directly as JSON.
+     *     parameters:
+     *       - in: path
+     *         name: grouphub
+     *         required: true
+     *         description: SAP Community grouphub name (e.g. Devtoberfest)
+     *         schema:
+     *           type: string
+     *       - in: query
+     *         name: format
+     *         required: false
+     *         description: When set to "json", returns JSON via the messages.author.* workaround instead of HTML.
+     *         schema:
+     *           type: string
+     *     responses:
+     *       200:
+     *         description: HTML admin page (default) or JSON list of grouphub members.
+     */
     app.get('/khoros/members/:grouphub', async (req, res) => {
         try {
-            let groupHub = ''
-            if (req.params.grouphub) {
-                groupHub = req.params.grouphub
-            } else {
-                groupHub = 'Devtoberfest'
-            }
+            const groupHub = req.params.grouphub || 'Devtoberfest'
             const memberQuery =
-                `select id, sso_id, login, email, first_name, last_name from users where node.id = 'grouphub:${req.params.grouphub}' `
+                `select id, sso_id, login, email, first_name, last_name from users where node.id = 'grouphub:${groupHub}' `
             const query = `${memberQuery} LIMIT 6000`
-            const outputQuery = `${communitysearchapibase}?q=${query}`
+            const loggedInQueryURL = `${communitysearchapibase}?q=${query}`
+
+            // JSON path — admin tooling that can't run in a logged-in browser
+            // session (CI scripts, server-to-server, etc.) gets the redacted
+            // anonymous result via the messages.author.* workaround.
+            if (req.query.format === 'json') {
+                const members = await khoros.searchGrouphubMembers(groupHub)
+                return res.type("application/json").status(200).send(members)
+            }
+
+            // Default HTML — the legacy admin workflow. The "FROM users" query
+            // that backs the first link returns 0 items for anonymous callers
+            // (silent permission revocation, mid-2026), but works as expected
+            // when the admin is signed in to community.sap.com in the same
+            // browser session, which is how this page has always been used.
             let output = '<!DOCTYPE html><html><body>'
-            output +=
-                `
-                \n<a href="${encodeURI(outputQuery)}"><h3>${groupHub} Members</h2></a>
-                `
+            output += `<h2>${groupHub} Members</h2>`
+            output += `
+                <p>
+                    <a href="${encodeURI(loggedInQueryURL)}" target="_blank">Open in browser (logged in)</a>
+                    &nbsp;—&nbsp; full PII (email, sso_id, first/last name); requires an active SAP Community login in this browser.
+                </p>
+                <p>
+                    <a href="?format=json" target="_blank">View as JSON (anonymous)</a>
+                    &nbsp;—&nbsp; works without login, but Khoros redacts <code>email</code> / <code>sso_id</code> for anonymous callers and only members who have <em>posted</em> in the grouphub appear (lurkers are not surfaced).
+                </p>
+            `
             output += `</body></html>`
             return res.type("text/html").status(200).send(output)
 

--- a/srv/smokeTestKhoros.mjs
+++ b/srv/smokeTestKhoros.mjs
@@ -70,5 +70,50 @@ await runCase('numeric scnId',   '139')
 await runCase('login scnId (underscored)', 'thomas_jung')
 await runCase('login scnId (legacy dotted form)', 'thomas.jung')
 
+// --- searchGrouphubMembers smoke test ----------------------------------
+// Devtoberfest is the canonical grouphub used everywhere else in the repo
+// (members.json, gameboard, /khoros/devtoberfestMembers). It always has
+// recent posts, so the messages.author.* workaround is guaranteed to find
+// some posters. Asserting on the SHAPE rather than a specific count, since
+// the live community traffic varies.
+//
+// Uses small page/cap params (pageSize:100, maxMessages:300) so the smoke
+// test stays fast and within Khoros' single-page comfort zone — production
+// callers use the defaults (500 / 5000).
+console.log(`\n[searchGrouphubMembers]  searchGrouphubMembers('Devtoberfest', {pageSize:100, maxMessages:300})`)
+try {
+    const r = await khoros.searchGrouphubMembers('Devtoberfest', { pageSize: 100, maxMessages: 300 })
+    assert(r?.status === 'success', 'envelope.status === "success"')
+    assert(r?.data?.list_item_type === 'user', 'envelope.data.list_item_type === "user"')
+    assert(Array.isArray(r?.data?.items), 'envelope.data.items is array')
+    assert((r?.data?.items?.length ?? 0) > 0, 'returns at least one posting member')
+    assert(r?.data?.size === r?.data?.items?.length, 'envelope.data.size matches items.length')
+
+    const first = r?.data?.items?.[0]
+    assert(typeof first?.id === 'string' && first.id.length > 0, 'first member.id is non-empty string')
+    assert(typeof first?.login === 'string' && first.login.length > 0, 'first member.login is non-empty string')
+    assert(first?.type === 'user', 'first member.type === "user"')
+
+    // Dedupe assertion — if the same author appears in 50 messages, they
+    // should appear ONCE in the deduped envelope.
+    const ids = r.data.items.map(u => u.id)
+    const uniqueIds = new Set(ids)
+    assert(ids.length === uniqueIds.size, 'envelope items are deduped by id')
+
+    // Pagination breadcrumb — proves the loop ran more than once and the
+    // result really came from stitched pages, not a single big request.
+    const pg = r?.data?._pagination
+    assert(pg && typeof pg === 'object', '_pagination breadcrumb present')
+    assert(pg?.pageSize === 100, '_pagination.pageSize echoes the option')
+    assert(pg?.maxMessages === 300, '_pagination.maxMessages echoes the option')
+    assert(typeof pg?.pages === 'number' && pg.pages >= 1, '_pagination.pages is a positive integer')
+    assert(typeof pg?.messagesScanned === 'number' && pg.messagesScanned >= pg.pages * 0,
+        '_pagination.messagesScanned is non-negative')
+    assert(typeof pg?.truncated === 'boolean', '_pagination.truncated is boolean')
+} catch (e) {
+    console.error(`  THREW: ${e.message}`)
+    failures++
+}
+
 console.log(`\n${failures === 0 ? 'ALL PASS' : `${failures} FAILURE(S)`}`)
 process.exit(failures === 0 ? 0 : 1)

--- a/srv/trees.mjs
+++ b/srv/trees.mjs
@@ -4,17 +4,12 @@ import search from '@inquirer/search'
 import fs from 'fs'
 import path from 'path'
 import excel from 'node-xlsx'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const khoros = require('./util/khoros.js')
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
-
-function sleep(milliseconds) {
-  const date = Date.now();
-  // eslint-disable-next-line no-useless-assignment -- used in do-while condition
-  let currentDate = null;
-  do {
-    currentDate = Date.now();
-  } while (currentDate - date < milliseconds);
-}
 
 function walkDir(dir, depth, maxDepth) {
   if (depth > maxDepth) return []
@@ -71,15 +66,27 @@ async function init() {
 
         scnId = scnId.toLowerCase()
 
-        const urlBadges = `https://people-api.services.sap.com/rs/badge/${scnId}?sort=timestamp,desc&size=1000`
-
-        const response = await fetch(urlBadges)
-        sleep(20)
-        const scnItems = await response.json()
+        // The legacy people-api.services.sap.com/rs/badge/<scnId> endpoint
+        // returned HTTP 410 Gone (verified 2026-06-02). Source the same
+        // {displayName, timestamp} pairs from Khoros via callUserAPI, which
+        // returns user_badges.items[].badge.title (= displayName) and
+        // .earned_date (= timestamp). callUserAPI handles dot/underscore
+        // login normalization internally, so no extra preprocessing here.
+        let scnItems
+        try {
+          scnItems = await khoros.callUserAPI(scnId)
+        } catch (error) {
+          console.error(`Error fetching SCN data for ${scnId}:`, error.message)
+          return
+        }
+        const userBadges = (scnItems?.data?.user_badges?.items || []).map(b => ({
+          displayName: b?.badge?.title,
+          timestamp: b?.earned_date
+        }))
 
         let points = 0
         let trees = false
-        for (let item of scnItems.content) {
+        for (let item of userBadges) {
           if(item.displayName === 'SAP TechEd in 2025 Registered Attendee' || item.displayName === 'SAP TechEd in 2025 Attendee - Bangalore'){
             trees = true
           }

--- a/srv/util/khoros.js
+++ b/srv/util/khoros.js
@@ -47,8 +47,145 @@ async function searchAuthor(whereClause) {
     if (body.status !== 'success') {
         throw new Error(`Khoros search failed: ${body.message || JSON.stringify(body)}`)
     }
+    if (!body?.data?.items?.length) {
+        // Empty-result canary for the per-user lookup. callUserAPI itself
+        // converts this into a thrown error one frame up (so the SVG/PNG
+        // routes render the standard "user not found" image), but we log
+        // first so a real anonymous-permission revocation shows up in the
+        // logs rather than as a generic user-not-found error to end users.
+        console.warn(
+            `[khoros] searchAuthor returned 0 items for WHERE ${whereClause}.`
+        )
+    }
     return body?.data?.items?.[0]?.author || null
 }
+
+// Low-level Khoros search helper — runs a raw `SELECT <fields> FROM messages
+// WHERE <whereClause>` against community.sap.com/khhcw49343 and returns the
+// raw `data.items` array. Centralizes the silent-empty warning so every
+// caller benefits.
+//
+// The `messages` collection is the **only** anonymously-readable surface
+// since mid-2026; anything that needs user, badge, or rank data must
+// project it via `author.*` field expansion through this helper.
+async function searchMessages(whereClause, fields, opts = {}) {
+    const request = require('then-request')
+    const limit = Number.isFinite(opts.limit) ? opts.limit : 100
+    const offset = Number.isFinite(opts.offset) && opts.offset > 0 ? opts.offset : 0
+    const tail = offset > 0 ? ` LIMIT ${limit} OFFSET ${offset}` : ` LIMIT ${limit}`
+    const query = `SELECT ${fields} FROM messages WHERE ${whereClause}${tail}`
+    const url = `${searchAPIURL}?q=${encodeURIComponent(query)}`
+    const res = await request('GET', url)
+    const body = JSON.parse(res.getBody())
+    if (body.status !== 'success') {
+        throw new Error(`Khoros search failed: ${body.message || JSON.stringify(body)}`)
+    }
+    const items = body?.data?.items || []
+    if (!items.length && offset === 0) {
+        // See searchAuthor's note. Empty-on-success is the silent symptom of
+        // a Khoros permission revocation; surfacing it as a warning means a
+        // future revocation gets noticed in logs instead of looking like a
+        // legitimate "no results" to callers. Only warn on the first page —
+        // an empty later page is a normal pagination terminator.
+        console.warn(
+            `[khoros] searchMessages returned 0 items for WHERE ${whereClause}.`
+        )
+    }
+    return items
+}
+module.exports.searchMessages = searchMessages
+
+// Returns the deduped list of authors who have posted in a given grouphub,
+// in the same envelope shape as the legacy /api/2.0/search?q=... FROM users
+// query that anonymous callers can no longer use (revoked mid-2026; the query
+// itself still returns HTTP 200 with status:"success" and items:[]).
+//
+// Pagination: Khoros 504s when asked to expand `author.*` over many thousand
+// rows in a single response. We page through `messages` in chunks of
+// `pageSize` (default 500 — verified safe; 1000 works but trends toward the
+// timeout, 6000 reliably 504s). We stop when:
+//   - Khoros returns fewer rows than pageSize (no more messages), OR
+//   - We've fetched `maxMessages` rows (hard ceiling, default 5000), OR
+//   - Two consecutive pages add no new authors (saturation — the rest of
+//     the grouphub is the same posters re-posting).
+//
+// Caveats vs. the deprecated FROM users query:
+//   - Only authors who have AUTHORED a message in the grouphub appear here.
+//     Lurkers (read-only members) are not surfaced — no anonymous workaround
+//     exists for them at the public tier.
+//   - PII fields like `email` and `sso_id` are redacted to "" by Khoros for
+//     anonymous callers. They are not projected.
+//   - `first_name`/`last_name` are populated only when the underlying user
+//     record exposes them; missing values are returned as undefined.
+async function searchGrouphubMembers(grouphub, opts = {}) {
+    const pageSize = Number.isFinite(opts.pageSize) ? opts.pageSize : 500
+    const maxMessages = Number.isFinite(opts.maxMessages) ? opts.maxMessages : 5000
+    const fields = 'author.id, author.login, author.first_name, author.last_name, author.view_href'
+    const where = `node.id = 'grouphub:${grouphub}'`
+
+    const byId = new Map()
+    let offset = 0
+    let saturationStreak = 0
+    let pages = 0
+    let truncated = false
+
+    while (offset < maxMessages) {
+        const limit = Math.min(pageSize, maxMessages - offset)
+        const page = await searchMessages(where, fields, { limit, offset })
+        pages += 1
+        const sizeBefore = byId.size
+        for (const it of page) {
+            const a = it?.author
+            if (a?.id && !byId.has(a.id)) {
+                byId.set(a.id, {
+                    type: 'user',
+                    id: a.id,
+                    login: a.login,
+                    first_name: a.first_name,
+                    last_name: a.last_name,
+                    view_href: a.view_href
+                })
+            }
+        }
+        const newAuthors = byId.size - sizeBefore
+
+        // No more messages — Khoros has exhausted the grouphub.
+        if (page.length < limit) {
+            break
+        }
+        // Saturation guard: if two consecutive full pages added no fresh
+        // authors, keep going one more page (community shape often has bursts
+        // of single-author replies); after THREE in a row, declare done.
+        if (newAuthors === 0) {
+            saturationStreak += 1
+            if (saturationStreak >= 3) break
+        } else {
+            saturationStreak = 0
+        }
+        offset += limit
+    }
+    if (offset >= maxMessages) {
+        truncated = true
+    }
+
+    const users = Array.from(byId.values())
+    return {
+        status: 'success',
+        message: '',
+        http_code: 200,
+        data: {
+            type: 'users',
+            list_item_type: 'user',
+            size: users.length,
+            items: users,
+            // Pagination breadcrumb so admins / smoke tests can see how the
+            // result was assembled. Not part of the legacy envelope, but
+            // additive — callers that ignore it are unaffected.
+            _pagination: { pages, messagesScanned: offset, truncated, pageSize, maxMessages }
+        }
+    }
+}
+module.exports.searchGrouphubMembers = searchGrouphubMembers
 
 // Resolves a user via two strategies, in order:
 //   1. If scnId looks numeric → SELECT ... WHERE author.id = '<scnId>'


### PR DESCRIPTION
## Context

Continues #21. After PR #20 fixed `callUserAPI` and PR #22 fixed the FLP Badge Signature Builder, a project-wide audit found two more surfaces broken by the mid-2026 anonymous-read revocation on Khoros' user-shaped collections, plus a separate dead-endpoint problem in the CLI tooling.

## Changes

### 1. `/khoros/members/:grouphub` — admin grouphub roster

The page returned an HTML link to a `SELECT ... FROM users WHERE node.id = 'grouphub:<x>'` Khoros Search query. That query now **silently** returns 0 items for anonymous callers (HTTP 200, `status:'success'`, `items:[]`) — the most insidious form of this regression because nothing errors.

Two-path solution:

- **Logged-in admin link is preserved** as-is — clicking it in a browser already authenticated to community.sap.com still returns the full PII payload (email, sso_id, first/last name). This is the existing admin workflow and we keep it.
- **New `?format=json` path** uses the anonymously-readable `messages.author.*` workaround via `khoros.searchGrouphubMembers()`. Documented caveats: only posting members appear (lurkers don't), and Khoros redacts email/sso_id for anonymous callers.

Pagination matters here: Khoros 504s when asked to expand `author.*` over many thousand rows. The helper paginates in pages of 500 (probed: 100/500/1000/2000 — 500 is the sweet spot, 6000 reliably 504s), dedupes by `author.id`, and stops on natural exhaustion, a `maxMessages` ceiling of 5000, or 3 consecutive saturated pages with no new authors. The response envelope includes a `data._pagination` breadcrumb (`pages, messagesScanned, truncated, pageSize, maxMessages`) so ops can detect ceiling truncation.

### 2. `trees.mjs` — tree-planting CLI

`https://people-api.services.sap.com/rs/badge/<scnId>` has returned HTTP 410 Gone since mid-2026. Migrated to `khoros.callUserAPI(scnId)` (which yesterday's PR #20 already retargeted to the working messages.author.* workaround), mapping `badge.title → displayName` and `earned_date → timestamp` so the rest of the script is unchanged.

### 3. Silent-empty canary

Added `console.warn` in `searchAuthor` / `searchMessages` for the `(status:success, items:[])` shape. A future revocation on a different Khoros collection will surface in logs instead of looking like a normal 'no results' to callers. Suppressed for non-zero pagination offsets so legitimate end-of-stream doesn't warn.

## Verification

**Smoke test** (`node srv/smokeTestKhoros.mjs` — extended): all 60 assertions pass against live Khoros, including new pagination-breadcrumb checks.

**Live HTTP** (local server, fresh `origin/main` ancestry):

| Route | Status | Time | Notes |
|---|---|---|---|
| `GET /khoros/members/Devtoberfest` (HTML) | 200 | 12ms | Both links present + redaction caveat |
| `GET /khoros/members/Devtoberfest?format=json` | 200 | 49s | **706 unique members**, 6 pages × 500 messages, `truncated:false` (saturation guard terminated naturally before the 5000-message ceiling) |
| `GET /khoros/user/139` (PR #22 regression check) | 200 | 800ms | 882 badges, 236-char signature, `view_href` populated — not regressed |

**Empty-result canary** logged 0 false positives across the verification run (every query returned data).

## Out of scope / future work

- The deeper Khoros surfaces in `khorosUser.js` (boards, threads, RSVPs) still inline `request('GET', ...)` calls. These are unaffected by the current revocation, but a follow-up refactor to route them through `util/khoros.js` would localize future API-shape changes to one file. Not bundled here to keep the diff focused.

Refs #21