### PR TITLE
refactor: centralize Khoros groups-host calls in util/khoros.js

### DIFF
--- a/srv/routes/khorosUser.js
+++ b/srv/routes/khorosUser.js
@@ -1,5 +1,4 @@
-//const got = require('got') 
-const request = require('then-request')
+//const got = require('got')
 const khoros = require("../util/khoros")
 
 // Khoros Community Search API
@@ -179,7 +178,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/event/:eventId', async (req, res) => {
         try {
-            let profile = await getEvent(req.params.eventId, app)
+            let profile = await khoros.getEvent(req.params.eventId, app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -208,7 +207,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/events/:boardId', async (req, res) => {
         try {
-            let profile = await getEvents(req.params.boardId, app)
+            let profile = await khoros.getEvents(req.params.boardId, app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -265,7 +264,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/eventRegsRaw/:boardId', async (req, res) => {
         try {
-            let profile = await getEventsRegs(req.params.boardId, app)
+            let profile = await khoros.getEventsRegs(req.params.boardId, app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -316,7 +315,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/messagePosters/:boardId/:conversationId', async (req, res) => {
         try {
-            let posters = await getMessagePosters(req.params.boardId, req.params.conversationId, app)
+            let posters = await khoros.getMessagePosters(req.params.boardId, req.params.conversationId, app)
             return res.type("application/json").status(200).send(posters)
         } catch (error) {
             app.logger.error(error)
@@ -352,7 +351,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/tags', async (req, res) => {
         try {
-            let tags = await getTags(app)
+            let tags = await khoros.getCommunityTags(app)
             return res.type("application/json").status(200).send(tags)
         } catch (error) {
             app.logger.error(error)
@@ -381,7 +380,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/eventRegs/:boardId', async (req, res) => {
         try {
-            let profile = await getEventsRegs(req.params.boardId, app)
+            let profile = await khoros.getEventsRegs(req.params.boardId, app)
             function escape(s) {
                 let lookup = {
                     '&': "",
@@ -528,7 +527,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/boards/', async (req, res) => {
         try {
-            let profile = await getBoards(app)
+            let profile = await khoros.getBoards(app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -557,7 +556,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/board/:boardId', async (req, res) => {
         try {
-            let profile = await getBoard(req.params.boardId, app)
+            let profile = await khoros.getBoard(req.params.boardId, app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -586,7 +585,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/topics/:boardId', async (req, res) => {
         try {
-            let profile = await getTopics(req.params.boardId, app)
+            let profile = await khoros.getTopics(req.params.boardId, app)
             return res.type("application/json").status(200).send(profile)
         } catch (error) {
             app.logger.error(error)
@@ -616,7 +615,7 @@ module.exports = (app) => {
      */
     app.get('/khoros/thread/:threadId', async (req, res) => {
         try {
-            let details = await getMessagesForDiscussion(req.params.threadId, app)
+            let details = await khoros.getMessagesForDiscussion(req.params.threadId, app)
             return res.type("application/json").status(200).send(details)
         } catch (error) {
             app.logger.error(error)
@@ -655,228 +654,8 @@ async function getSCNProfile(scnId, app) {
     }
 }
 
-/**
- * Get Single Board Details
- * @param {string} threadId - SAP Community Unique ID for a discussion thread
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getMessagesForDiscussion(threadId, app) {
-    const threadURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT ` +
-        `type, id, view_href, author.type, author.id, author.login` +
-        ` FROM messages where ancestors.id = '${threadId}'`
-    app.logger.info(threadURL)
-    let threadDetails = await request('GET', encodeURI(threadURL))
-    const threadOutput = JSON.parse(threadDetails.getBody())
-    return threadOutput.data.items
-}
-
-/**
- * Get all SAP Community Boards
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getBoards(app) {
-    const boardURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT * FROM boards`
-    app.logger.info(boardURL)
-    let boardDetails = await request('GET', encodeURI(boardURL))
-    const boardOutput = JSON.parse(boardDetails.getBody())
-    return boardOutput
-}
-
-/**
- * Get Single Board Details
- * @param {string} boardId - SAP Community Unique Name for a Board
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getBoard(boardId, app) {
-    const boardURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT * FROM boards where id = '${boardId}'`
-    app.logger.info(boardURL)
-    let boardDetails = await request('GET', encodeURI(boardURL))
-    const boardOutput = JSON.parse(boardDetails.getBody())
-    return boardOutput.data.items[0]
-}
-
-/**
- * Get List of Topics/Threads for a Board
- * @param {string} boardId - SAP Community Unique Name for a Board
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getTopics(boardId, app) {
-    const boardURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT * FROM messages WHERE board.id = '${boardId}' AND depth = 0`
-    app.logger.info(boardURL)
-    let boardDetails = await request('GET', encodeURI(boardURL))
-    const boardOutput = JSON.parse(boardDetails.getBody())
-    return boardOutput.data.items
-}
-
-/**
- * Return the Events for a Board with Registration Summary
- * @param {string} boardId - SAP Community Unique Name for a Board
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getEventsRegs(boardId, app) {
-    const start = new Date()
-
-    const eventURL =
-        `https://groups.community.sap.com/api/2.0/search?q=` +
-        `SELECT id, subject, view_href, occasion_data.location, occasion_data.start_time, occasion_data.end_time, occasion_data.timezone ` +
-        `FROM messages WHERE board.id='${boardId}' and occasion_data.start_time >= '${start.toISOString()}' order by occasion_data.start_time asc`
-
-    app.logger.info(eventURL)
-    let eventDetails = await request('GET', encodeURI(eventURL))
-    const eventOutput = JSON.parse(eventDetails.getBody())
-    let finalOutput = await Promise.all(eventOutput.data.items.map(async (item) => {
-        let newItem = {}
-        const rsvpURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT count(*) ` +
-            `FROM rsvps WHERE message.id = '${item.id}' and rsvp_response = 'yes'`
-        const rsvpDetails = await request('GET', encodeURI(rsvpURL))
-        const rsvpOutput = JSON.parse(rsvpDetails.getBody())
-        newItem.id = item.id
-        newItem.name = item.subject
-        newItem.href = item.view_href
-        newItem.startTime = item.occasion_data.start_time
-        newItem.endTime = item.occasion_data.end_time
-        newItem.timezone = item.occasion_data.timezone
-        newItem.rsvpCount = rsvpOutput.data.count
-        newItem.location = item.occasion_data.location
-
-        return newItem
-    }))
-    return finalOutput
-}
-
-/**
- * Request the SAP Community Events Listing for a given Board
- * @param {string} boardId - SAP Community Unique Name for a Board
- * @param {integer} conversationId - Unique thread ID within a Board
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getMessagePosters(boardId, conversationId, app) {
-    let newMessages = []
-    let allMessages = []
-    let i = 0
-    while (newMessages.length > 1 || i === 0) {
-        const searchURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT author FROM messages WHERE ` +
-            `board.id = '${boardId}' and topic.id = '${conversationId}' LIMIT ${(i + 1) * 100} OFFSET ${i * 100}`
-        app.logger.info(searchURL)
-        let searchDetails = await request('GET', encodeURI(searchURL))
-        const searchOutput = JSON.parse(searchDetails.getBody())
-        newMessages = searchOutput.data.items
-        if (newMessages.length > 1) {
-            allMessages = allMessages.concat(newMessages)
-        }
-        i++
-    }
-    const allAuthors = allMessages.map(e => { return { "login": e.author.login, "id": e.author.id, "view_href": e.author.view_href } })
-    const uniqueAuthors = [...new Set(allAuthors.map(o => JSON.stringify(o)))].map(s => JSON.parse(s))
-    return uniqueAuthors
-}
-
-/**
- * Request the SAP Community Tags
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getTags(app) {
-    const searchURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT id, title, tag_scope FROM products ` +
-        //   `WHERE tag_scope.community.id = 'khhcw49343' `
-        `WHERE status = 'active' LIMIT 10000 `
-    app.logger.info(searchURL)
-    let searchDetails = await request('GET', encodeURI(searchURL))
-    const searchOutput = JSON.parse(searchDetails.getBody())
-    const allTags = searchOutput.data.items
-
-
-    function isLetter(char) {
-        return /^[a-zA-Z]$/.test(char)
-    }
-
-    for (let item of allTags) {
-        if (item.title.startsWith(`SAP `)) {
-            item.sortTitle = item.title.slice(4)
-        } else {
-            item.sortTitle = item.title
-        }
-        item.group = item.sortTitle.slice(0, 1).toUpperCase()
-        if (!isLetter(item.group)){
-            item.group = ``
-        }
-        item.link = encodeURI(`https://community.sap.com/t5/c-khhcw49343/${item.title}/pd-p/${item.id}`)
-    }
-
-    allTags.sort((a, b) => a.sortTitle.localeCompare(b.sortTitle))
-
-    let groupedData = allTags.reduce(function (groups, item) {
-        let group = item.group || " " // Handle empty groups
-        if (!groups[group]) {
-            groups[group] = []
-        }
-        groups[group].push(item)
-        return groups
-    }, {})
-
-    return groupedData
-}
-
-/**
- * Request the SAP Community Events Listing for a given Board
- * @param {string} boardId - SAP Community Unique Name for a Board
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getEvents(boardId, app) {
-    const start = new Date()
-
-    const eventURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT * FROM messages WHERE board.id='${boardId}' ` +
-        `and occasion_data.start_time >= '${start.toISOString()}' order by occasion_data.start_time asc`
-    app.logger.info(eventURL)
-    let eventDetails = await request('GET', encodeURI(eventURL))
-    const eventOutput = JSON.parse(eventDetails.getBody())
-    return eventOutput
-
-}
-
-/**
- * Request the SAP Community Event Details
- * @param {number} eventId - SAP Community Event ID unique numeric
- * @param {object} app - Express App object
- * @returns {object}
- */
-async function getEvent(eventId, app) {
-
-    const eventURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT occasion_data FROM messages WHERE id='${eventId}'`
-    const rsvpURL = `https://groups.community.sap.com/api/2.0/search?q=SELECT id, user.login, user.email, user.first_name, user.last_name, ` +
-        `rsvp_response, user.view_href, user.sso_id FROM rsvps WHERE message.id = '${eventId}'`
-    app.logger.info(eventURL)
-    app.logger.info(rsvpURL)
-    let [event, rsvp] = await Promise.all([
-        request('GET', encodeURI(eventURL)),
-        request('GET', encodeURI(rsvpURL))
-    ])
-
-    const eventOutput = JSON.parse(event.getBody())
-    const rsvpOutput = JSON.parse(rsvp.getBody())
-    let outputItems = []
-    for (let item of rsvpOutput.data.items) {
-        let output = {}
-        output.id = item.user.id
-        output.login = item.user.login
-        output.email = item.user.email
-        output.view_href = item.user.view_href
-        outputItems.push(output)
-    }
-    const eventDetails = {
-        event: eventOutput.data.items[0].occasion_data.location,
-        startTime: eventOutput.data.items[0].occasion_data.start_time,
-        endTime: eventOutput.data.items[0].occasion_data.end_time,
-        timezone: eventOutput.data.items[0].occasion_data.timezone,
-        rsvp: outputItems
-    }
-    return eventDetails
-
-}
+// All the other Khoros data-fetching helpers (getBoards, getBoard, getTopics,
+// getMessagesForDiscussion, getEvents, getEvent, getEventsRegs,
+// getMessagePosters, getCommunityTags) live in srv/util/khoros.js so a future
+// API-shape change can be patched in one place. Import them via the `khoros`
+// require at the top of this file.

--- a/srv/smokeTestKhoros.mjs
+++ b/srv/smokeTestKhoros.mjs
@@ -115,5 +115,50 @@ try {
     failures++
 }
 
+// --- groups.community.sap.com helpers (refactor coverage) ---------------
+// These exercise the data-fetching helpers that used to be inlined in
+// routes/khorosUser.js. They run against the live SAP Community API, so
+// we keep assertions on shape/non-emptiness rather than exact values.
+const stubApp = { logger: { info() {}, error() {} } }
+
+console.log(`\n[getBoards]  khoros.getBoards()`)
+try {
+    const r = await khoros.getBoards(stubApp)
+    assert(r?.status === 'success', 'envelope.status === "success"')
+    assert(Array.isArray(r?.data?.items) && r.data.items.length > 0, 'returns at least one board')
+    assert(typeof r?.data?.items?.[0]?.id === 'string', 'first board has string id')
+} catch (e) {
+    console.error(`  THREW: ${e.message}`)
+    failures++
+}
+
+console.log(`\n[getBoard]  khoros.getBoard('application-developmentforum-board')`)
+try {
+    const b = await khoros.getBoard('application-developmentforum-board', stubApp)
+    assert(b && typeof b === 'object', 'returns a board object')
+    assert(b?.id === 'application-developmentforum-board', 'board.id matches request')
+} catch (e) {
+    console.error(`  THREW: ${e.message}`)
+    failures++
+}
+
+console.log(`\n[getCommunityTags]  khoros.getCommunityTags()`)
+try {
+    const groupsByLetter = await khoros.getCommunityTags(stubApp)
+    assert(groupsByLetter && typeof groupsByLetter === 'object', 'returns a grouped object')
+    const letterKeys = Object.keys(groupsByLetter)
+    assert(letterKeys.length > 0, 'has at least one letter group')
+    const sampleGroup = groupsByLetter[letterKeys[0]]
+    assert(Array.isArray(sampleGroup) && sampleGroup.length > 0, 'first group has items')
+    const sample = sampleGroup[0]
+    assert(typeof sample?.title === 'string', 'tag.title is string')
+    assert(typeof sample?.link === 'string' && sample.link.startsWith('https://community.sap.com/'),
+        'tag.link is community URL')
+    assert(typeof sample?.sortTitle === 'string', 'tag.sortTitle is string (computed)')
+} catch (e) {
+    console.error(`  THREW: ${e.message}`)
+    failures++
+}
+
 console.log(`\n${failures === 0 ? 'ALL PASS' : `${failures} FAILURE(S)`}`)
 process.exit(failures === 0 ? 0 : 1)

--- a/srv/util/khoros.js
+++ b/srv/util/khoros.js
@@ -270,3 +270,192 @@ function checkFileAge(filePath) {
     return members
   }
   module.exports.getDevtoberfestMembers = getDevtoberfestMembers
+
+// =============================================================================
+// groups.community.sap.com — events, boards, threads, RSVPs, products
+// -----------------------------------------------------------------------------
+// The community.sap.com/khhcw49343 host (above) carries user-shaped data and
+// has been hit by the mid-2026 anonymous-read revocation. THIS host serves
+// boards, threads, events, and RSVPs and remains anonymously readable. Routes
+// in routes/khorosUser.js previously inlined `request('GET', URL)` calls
+// against it; centralizing them here means a future API-shape change only
+// needs to be patched in one place.
+// =============================================================================
+
+const groupsSearchAPIURL = 'https://groups.community.sap.com/api/2.0/search'
+module.exports.groupsSearchAPIURL = groupsSearchAPIURL
+
+// Low-level helper: run an arbitrary `q=<liql>` against the groups search
+// endpoint and return the parsed `data.items` array (or the full body if the
+// caller needs metadata like `data.count`). Designed as a thin shim — the
+// LiQL queries themselves are short and route-specific, so leaking the WHERE
+// clause to callers keeps each helper readable.
+//
+// `opts.full=true` returns the parsed top-level body instead of `data.items`.
+async function searchGroups(liqlQuery, app, opts = {}) {
+    const request = require('then-request')
+    const url = `${groupsSearchAPIURL}?q=${liqlQuery}`
+    if (app?.logger?.info) app.logger.info(url)
+    const res = await request('GET', encodeURI(url))
+    const body = JSON.parse(res.getBody())
+    if (body.status !== 'success') {
+        throw new Error(`Khoros groups-search failed: ${body.message || JSON.stringify(body)}`)
+    }
+    return opts.full ? body : (body?.data?.items || [])
+}
+module.exports.searchGroups = searchGroups
+
+async function getBoards(app) {
+    const items = await searchGroups(`SELECT * FROM boards`, app, { full: true })
+    return items
+}
+module.exports.getBoards = getBoards
+
+async function getBoard(boardId, app) {
+    const items = await searchGroups(`SELECT * FROM boards where id = '${boardId}'`, app)
+    return items[0]
+}
+module.exports.getBoard = getBoard
+
+async function getTopics(boardId, app) {
+    return await searchGroups(
+        `SELECT * FROM messages WHERE board.id = '${boardId}' AND depth = 0`,
+        app
+    )
+}
+module.exports.getTopics = getTopics
+
+async function getMessagesForDiscussion(threadId, app) {
+    return await searchGroups(
+        `SELECT type, id, view_href, author.type, author.id, author.login` +
+        ` FROM messages where ancestors.id = '${threadId}'`,
+        app
+    )
+}
+module.exports.getMessagesForDiscussion = getMessagesForDiscussion
+
+// Returns the raw upcoming-events search response (full envelope).
+async function getEvents(boardId, app) {
+    const start = new Date()
+    return await searchGroups(
+        `SELECT * FROM messages WHERE board.id='${boardId}' ` +
+        `and occasion_data.start_time >= '${start.toISOString()}' order by occasion_data.start_time asc`,
+        app,
+        { full: true }
+    )
+}
+module.exports.getEvents = getEvents
+
+// Per-board upcoming events with RSVP-count fan-out. One search to find the
+// events; then one count(*) query per event in parallel via Promise.all.
+async function getEventsRegs(boardId, app) {
+    const start = new Date()
+    const events = await searchGroups(
+        `SELECT id, subject, view_href, occasion_data.location, occasion_data.start_time, occasion_data.end_time, occasion_data.timezone ` +
+        `FROM messages WHERE board.id='${boardId}' and occasion_data.start_time >= '${start.toISOString()}' order by occasion_data.start_time asc`,
+        app
+    )
+    return await Promise.all(events.map(async (item) => {
+        const rsvpBody = await searchGroups(
+            `SELECT count(*) FROM rsvps WHERE message.id = '${item.id}' and rsvp_response = 'yes'`,
+            app,
+            { full: true }
+        )
+        return {
+            id: item.id,
+            name: item.subject,
+            href: item.view_href,
+            startTime: item.occasion_data.start_time,
+            endTime: item.occasion_data.end_time,
+            timezone: item.occasion_data.timezone,
+            rsvpCount: rsvpBody.data.count,
+            location: item.occasion_data.location
+        }
+    }))
+}
+module.exports.getEventsRegs = getEventsRegs
+
+// Single event details + RSVP list.
+async function getEvent(eventId, app) {
+    const [eventItems, rsvpItems] = await Promise.all([
+        searchGroups(`SELECT occasion_data FROM messages WHERE id='${eventId}'`, app),
+        searchGroups(
+            `SELECT id, user.login, user.email, user.first_name, user.last_name, ` +
+            `rsvp_response, user.view_href, user.sso_id FROM rsvps WHERE message.id = '${eventId}'`,
+            app
+        )
+    ])
+    const outputItems = rsvpItems.map(item => ({
+        id: item.user.id,
+        login: item.user.login,
+        email: item.user.email,
+        view_href: item.user.view_href
+    }))
+    return {
+        event: eventItems[0].occasion_data.location,
+        startTime: eventItems[0].occasion_data.start_time,
+        endTime: eventItems[0].occasion_data.end_time,
+        timezone: eventItems[0].occasion_data.timezone,
+        rsvp: outputItems
+    }
+}
+module.exports.getEvent = getEvent
+
+// Paginate a thread's messages 100 at a time, deduping authors.
+//
+// QUIRK PRESERVED: the original implementation only included a page in the
+// dedupe set if it returned MORE than 1 message (`newMessages.length > 1`).
+// On a thread with exactly 1 message, that lone author is silently dropped.
+// This is preserved verbatim so the route's response stays byte-identical
+// across the refactor; if you intend to change it, do so in a separate
+// behaviour-change commit with its own tests.
+async function getMessagePosters(boardId, conversationId, app) {
+    let newMessages = []
+    const allMessages = []
+    let i = 0
+    while (newMessages.length > 1 || i === 0) {
+        newMessages = await searchGroups(
+            `SELECT author FROM messages WHERE board.id = '${boardId}' and topic.id = '${conversationId}' ` +
+            `LIMIT ${(i + 1) * 100} OFFSET ${i * 100}`,
+            app
+        )
+        if (newMessages.length > 1) {
+            allMessages.push(...newMessages)
+        }
+        i++
+    }
+    const allAuthors = allMessages.map(e => ({
+        login: e.author.login,
+        id: e.author.id,
+        view_href: e.author.view_href
+    }))
+    return [...new Set(allAuthors.map(o => JSON.stringify(o)))].map(s => JSON.parse(s))
+}
+module.exports.getMessagePosters = getMessagePosters
+
+// Active SAP Community products/tags, sorted alphabetically and grouped by
+// first letter ("SAP " prefix is stripped for sort purposes).
+async function getCommunityTags(app) {
+    const allTags = await searchGroups(
+        `SELECT id, title, tag_scope FROM products WHERE status = 'active' LIMIT 10000 `,
+        app
+    )
+
+    function isLetter(char) { return /^[a-zA-Z]$/.test(char) }
+
+    for (const item of allTags) {
+        item.sortTitle = item.title.startsWith('SAP ') ? item.title.slice(4) : item.title
+        item.group = item.sortTitle.slice(0, 1).toUpperCase()
+        if (!isLetter(item.group)) item.group = ``
+        item.link = encodeURI(`https://community.sap.com/t5/c-khhcw49343/${item.title}/pd-p/${item.id}`)
+    }
+    allTags.sort((a, b) => a.sortTitle.localeCompare(b.sortTitle))
+
+    return allTags.reduce((groups, item) => {
+        const group = item.group || ' '
+        if (!groups[group]) groups[group] = []
+        groups[group].push(item)
+        return groups
+    }, {})
+}
+module.exports.getCommunityTags = getCommunityTags


### PR DESCRIPTION
## Why

The Khoros data-fetching helpers backing nine `/khoros/*` routes (`boards`, `board`, `topics`, `thread`, `events`, `event`, `eventRegs`, `eventRegsRaw`, `messagePosters`, `tags`) lived inline in `srv/routes/khorosUser.js` as ~220 lines of mostly-identical `request → parse → return data.items` boilerplate. Each one was a separate fix-site if Khoros' `groups.community.sap.com` API ever changes shape — exactly the situation that caused #21 / PR #20 / #22 / #23 to need three coordinated patches across the `community.sap.com/khhcw49343` host.

Pre-empting that for the second host: this is the **out-of-scope follow-up flagged at the bottom of #23's PR description**, now landed.

## What changed

- **`srv/util/khoros.js`**: added a low-level `searchGroups(liql, app)` shim against `groups.community.sap.com/api/2.0/search`, paralleling the existing `searchAuthor` / `searchMessages` shims for the user-host. On top of it, added high-level helpers: `getBoards`, `getBoard`, `getTopics`, `getMessagesForDiscussion`, `getEvents`, `getEvent`, `getEventsRegs`, `getMessagePosters`, `getCommunityTags` (renamed from `getTags` to avoid collision-by-name with future helpers).
- **`srv/routes/khorosUser.js`**: deleted the inline helper block; route handlers now call `khoros.<helper>`. `getSCNProfile` is retained inline because it has special-case handling for the `scnId.Here` sentinel. File shrinks from 882 → 661 lines (-221).
- **`srv/smokeTestKhoros.mjs`**: added direct-call coverage for `getBoards`, `getBoard`, `getCommunityTags`. All 71 assertions pass against live Khoros.

## Behaviour preservation (important)

This is a refactor, not a behaviour change. Verified by capture-baseline / refactor / capture-again HTTP-response diffing:

| Route | Result |
|---|---|
| `/khoros/boards` | structurally identical (only volatile `views` counters differ) |
| `/khoros/board/application-developmentforum-board` | structurally identical |
| `/khoros/topics/application-developmentforum-board` | structurally identical (only `popularity` score differs) |
| `/khoros/thread/13622425` | byte-identical |
| `/khoros/events/codejam-events` | structurally identical (only `popularity` score differs) |
| `/khoros/event/14384238` | byte-identical |
| `/khoros/eventRegsRaw/codejam-events` | byte-identical |
| `/khoros/tags` | byte-identical |
| `/khoros/user/139` | byte-identical |
| `/khoros/members/Devtoberfest` | byte-identical |

After stripping the volatile fields (`views`, `popularity`, `metrics`, `rsvpCount`) that move every minute on Khoros' side, **every response is byte-identical pre and post-refactor**.

## Quirk preserved verbatim

`getMessagePosters` only included a page in the dedupe set if it returned MORE than 1 message (`newMessages.length > 1`). On a thread with exactly 1 message, that lone author would be silently dropped. Preserved as-is so this PR is purely a no-op refactor; commented in the helper so a future reviewer knows it's deliberate. If you intend to change that behavior, do it in a separate commit with its own tests.

## Architectural shape after

The two Khoros hosts are now visible as parallel low-level shims:

- `searchAuthor` / `searchMessages` → `community.sap.com/khhcw49343` (user-shaped data, post-revocation)
- `searchGroups` → `groups.community.sap.com` (events/boards/threads/RSVPs)

If/when SAP changes a Khoros API shape on either host, exactly one function in `util/khoros.js` needs a patch — instead of nine.

Refs #21