### PR TITLE
chore(dev): add install:all script for the Vue SPA setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,19 +8,25 @@ All development commands are run from the `srv/` directory (the Node.js service)
 
 ```bash
 cd srv
-npm install          # Install dependencies
-npm run dev          # Start with nodemon (auto-reload)
-npm start            # Start production server (port 4000 by default, overridden by PORT env var)
-npm run types        # Regenerate TypeScript declarations in srv/types/
+npm run install:all     # Install Express deps AND the nested Vue app's deps (one-time per checkout)
+npm run dev             # Start Express + Vite dev server (concurrent, ports 4000 and 5173)
+npm run dev:server-only # Start Express only (nodemon, port 4000) — when the Vue app isn't needed
+npm start               # Start production server (port 4000 by default, overridden by PORT env var)
+npm run types           # Regenerate TypeScript declarations in srv/types/
+npm run test:vue        # Run the Vue app's Vitest unit tests
 ```
+
+> **Why `install:all` and not `npm install`?** The Vue SPA at `srv/app/profile-vue/` has its own `package.json` (Vite/Vue/UI5 don't ship to production). Plain `npm install` in `srv/` only handles Express's deps. `install:all` runs both. We don't use a `postinstall` hook for security reasons (postinstall scripts are a supply-chain attack vector).
+
+When `npm run dev` is running, open `http://localhost:5173/profile/<scn-id>` (Vite's dev server proxies API calls to Express).
 
 To build the MTAR for SAP BTP Cloud Foundry deployment, run from the root:
 
 ```bash
-npm run build        # Runs mbt build (requires Cloud MTA Build Tool)
+npm run build        # Builds the Vue SPA, then runs mbt build (requires Cloud MTA Build Tool)
 ```
 
-There are no automated tests (`npm test` is a stub).
+There are no automated tests for the Express service (`npm test` is a stub). The Vue app has 73 Vitest unit tests; run via `npm run test:vue`.
 
 ## Architecture
 

--- a/srv/package.json
+++ b/srv/package.json
@@ -38,6 +38,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "install:vue": "npm --prefix app/profile-vue install",
+    "install:all": "npm install && npm run install:vue",
     "dev": "concurrently -k -n express,vue -c blue,magenta \"npm:dev:express\" \"npm:dev:vue\"",
     "dev:express": "nodemon index",
     "dev:server-only": "nodemon index",


### PR DESCRIPTION
## Summary

Follow-up to #25. Adds an explicit `install:all` script and updates `CLAUDE.md` so contributors don't hit the `'vite' is not recognized` error on first `npm run dev`.

## Why

After #25 merged, running `npm install` in `srv/` only installs Express's deps, not the nested Vue SPA's deps at `srv/app/profile-vue/` (which has its own `package.json` since Vite/Vue/UI5 don't ship to production). First `npm run dev` then fails with:

```
[vue] 'vite' is not recognized as an internal or external command
```

Hit by a real contributor immediately after merge.

## Fix

Two new scripts in `srv/package.json`:

```json
"install:vue": "npm --prefix app/profile-vue install",
"install:all": "npm install && npm run install:vue"
```

Workflow becomes:

```bash
cd srv
npm run install:all   # one-time per checkout (Express + Vue deps)
npm run dev           # both servers come up
```

`CLAUDE.md` updated to document the new commands and explain why we don't use a `postinstall` hook (postinstall scripts are a known supply-chain attack vector — the project owner specifically disables them).

## Why not `postinstall`?

A `postinstall` hook would auto-trigger on plain `npm install` and "just work" — but it's also one of the most common supply-chain attack vectors in the npm ecosystem. The project owner has them disabled globally for security; an explicit `install:all` is the right tradeoff (one extra command at setup, zero magic afterward).

## Verification

```bash
cd srv && npm run install:all
# → npm install in srv/, then npm install in app/profile-vue/
cd srv && npm run dev
# → both servers start cleanly
```
