### PR TITLE
chore: bump version to 5.4.2

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -1,6 +1,6 @@
 _schema-version: "3.3"
 ID: scn-badges
-version: 5.4.1
+version: 5.4.2
 modules:
   - name: scn-badges-srv
     type: nodejs

--- a/srv/package-lock.json
+++ b/srv/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scn-badges-srv",
-      "version": "5.4.1",
+      "version": "5.4.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cloudnative/health-connect": "^2.1.0",

--- a/srv/package.json
+++ b/srv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "SCN Badges Service Layer",
   "engines": {
     "node": "^22.0.0 || ^24.0.0"


### PR DESCRIPTION
Patch bump in srv/package.json and mta.yaml for the post-#28 fixes (avatar API, theme switcher, 404 handling, invisible tab labels). Two version files are kept in sync per CLAUDE.md.

MTAR built and ready at `mta_archives/scn-badges_5.4.2.mtar` (197 MB).