### PR TITLE
i18n: translate Vue-overhaul keys for 10 non-English locales (closes #34)

### DIFF
--- a/srv/app/profile-vue/src/i18n/locales/de.json
+++ b/srv/app/profile-vue/src/i18n/locales/de.json
@@ -11,6 +11,7 @@
     "url": "Profil-URL",
     "Toolbar2": "Unterschrift",
     "signaturePreview": "Signaturvorschau",
+    "signature2Preview": "Helle Signaturvorschau",
     "signature": "Unterschrift",
     "badges": "Abzeichen",
     "fname": "Vorname",
@@ -26,35 +27,35 @@
     "limitErr": "Sie können nur fünf Abzeichen auswählen"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Benutzer '{scnId}' wurde nicht gefunden.",
+    "network": "Der SAP Community-Dienst ist nicht erreichbar. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+    "unexpected": "Beim Laden des Profils ist ein unerwarteter Fehler aufgetreten.",
+    "retry": "Erneut versuchen"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tabelle",
+    "grid": "Raster"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "Nur URL",
+    "copy": "Kopieren",
+    "copied": "Kopiert",
+    "copyFallback": "Markiert — drücken Sie Strg+C zum Kopieren"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "SAP Community-Signatur von {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Vorschau",
+    "expand": "Signatur anzeigen",
+    "collapse": "Signatur ausblenden"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Design umschalten",
+    "light": "Design: Hell (Klicken für Dunkel)",
+    "dark": "Design: Dunkel (Klicken für Automatisch)",
+    "auto": "Design: Automatisch — folgt dem System (Klicken für Hell)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/es.json
+++ b/srv/app/profile-vue/src/i18n/locales/es.json
@@ -11,6 +11,7 @@
     "url": "URL del Perfil",
     "Toolbar2": "Firma",
     "signaturePreview": "Vista Previa de la Firma",
+    "signature2Preview": "Vista Previa de la Firma Clara",
     "signature": "Firma",
     "badges": "Distintivos",
     "fname": "Nombre",
@@ -26,35 +27,35 @@
     "limitErr": "Solo puedes seleccionar cinco distintivos"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Usuario '{scnId}' no encontrado.",
+    "network": "No se pudo conectar con el servicio de la Comunidad SAP. Compruebe su conexión e inténtelo de nuevo.",
+    "unexpected": "Ocurrió algo inesperado al cargar el perfil.",
+    "retry": "Reintentar"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tabla",
+    "grid": "Cuadrícula"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "Solo URL",
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyFallback": "Seleccionado — presione Ctrl+C para copiar"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "Firma de la Comunidad SAP de {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Vista Previa",
+    "expand": "Mostrar firma",
+    "collapse": "Ocultar firma"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Cambiar tema",
+    "light": "Tema: claro (haga clic para oscuro)",
+    "dark": "Tema: oscuro (haga clic para automático)",
+    "auto": "Tema: automático — sigue al sistema (haga clic para claro)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/fr.json
+++ b/srv/app/profile-vue/src/i18n/locales/fr.json
@@ -11,6 +11,7 @@
     "url": "URL du Profil",
     "Toolbar2": "Signature",
     "signaturePreview": "Aperçu de la Signature",
+    "signature2Preview": "Aperçu de la Signature Claire",
     "signature": "Signature",
     "badges": "Badges",
     "fname": "Prénom",
@@ -26,35 +27,35 @@
     "limitErr": "Vous ne pouvez sélectionner que cinq badges"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Utilisateur '{scnId}' introuvable.",
+    "network": "Impossible de joindre le service de la Communauté SAP. Vérifiez votre connexion et réessayez.",
+    "unexpected": "Une erreur inattendue s'est produite lors du chargement du profil.",
+    "retry": "Réessayer"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tableau",
+    "grid": "Grille"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "URL uniquement",
+    "copy": "Copier",
+    "copied": "Copié",
+    "copyFallback": "Sélectionné — appuyez sur Ctrl+C pour copier"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "Signature de la Communauté SAP de {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Aperçu",
+    "expand": "Afficher la signature",
+    "collapse": "Masquer la signature"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Changer de thème",
+    "light": "Thème : clair (cliquer pour sombre)",
+    "dark": "Thème : sombre (cliquer pour automatique)",
+    "auto": "Thème : automatique — suit le système (cliquer pour clair)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/hi.json
+++ b/srv/app/profile-vue/src/i18n/locales/hi.json
@@ -11,6 +11,7 @@
     "url": "प्रोफ़ाइल URL",
     "Toolbar2": "हस्ताक्षर",
     "signaturePreview": "हस्ताक्षर पूर्वावलोकन",
+    "signature2Preview": "हल्का हस्ताक्षर पूर्वावलोकन",
     "signature": "हस्ताक्षर",
     "badges": "बैज",
     "fname": "प्रथम नाम",
@@ -26,35 +27,35 @@
     "limitErr": "आप केवल पांच बैज चुन सकते हैं"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "उपयोगकर्ता '{scnId}' नहीं मिला।",
+    "network": "SAP समुदाय सेवा से संपर्क नहीं हो सका। अपना कनेक्शन जांचें और पुनः प्रयास करें।",
+    "unexpected": "प्रोफ़ाइल लोड करते समय कुछ अनपेक्षित हुआ।",
+    "retry": "पुनः प्रयास करें"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "तालिका",
+    "grid": "ग्रिड"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "केवल URL",
+    "copy": "कॉपी करें",
+    "copied": "कॉपी हो गया",
+    "copyFallback": "चुना गया — कॉपी करने के लिए Ctrl+C दबाएं"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "{scnId} SAP समुदाय हस्ताक्षर"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "पूर्वावलोकन",
+    "expand": "हस्ताक्षर दिखाएं",
+    "collapse": "हस्ताक्षर छिपाएं"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "थीम बदलें",
+    "light": "थीम: हल्का (डार्क के लिए क्लिक करें)",
+    "dark": "थीम: डार्क (ऑटो के लिए क्लिक करें)",
+    "auto": "थीम: ऑटो — सिस्टम के अनुसार (हल्के के लिए क्लिक करें)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/i-klingon.json
+++ b/srv/app/profile-vue/src/i18n/locales/i-klingon.json
@@ -11,6 +11,7 @@
     "url": "Profile URL",
     "Toolbar2": "Signature",
     "signaturePreview": "Signature Preview",
+    "signature2Preview": "Light Signature Preview",
     "signature": "Signature",
     "badges": "Badges",
     "fname": "pe'meH pong",
@@ -26,10 +27,10 @@
     "limitErr": "You can only select five badges"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Usor '{scnId}' tu'lu'be'.",
+    "network": "qaStaH nuq jay'? SAP Qumwl' lengmeH naDev vIghoSlaHbe'. Connection inspect 'ej iterum tenta.",
+    "unexpected": "qaStaH nuq! Profile loading mIq Qaghta'.",
+    "retry": "Retry — iterum tenta"
   },
   "view": {
     "table": "Table",
@@ -39,22 +40,22 @@
     "html": "HTML",
     "markdown": "Markdown",
     "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "copy": "Copy — choS",
+    "copied": "Qapla' — choSta'",
+    "copyFallback": "wIvta' — Ctrl+C yIqIp"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "{scnId} SAP Qumwl' signature"
   },
   "mobile": {
     "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "expand": "Signature 'angmoH",
+    "collapse": "Signature So'moH"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Theme choH",
+    "light": "Theme: wovmoH (HurghmoH lo'meH yIqIp)",
+    "dark": "Theme: HurghmoH (auto lo'meH yIqIp)",
+    "auto": "Theme: auto — system tlhej (wovmoH lo'meH yIqIp)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/it.json
+++ b/srv/app/profile-vue/src/i18n/locales/it.json
@@ -11,6 +11,7 @@
     "url": "URL del Profilo",
     "Toolbar2": "Firma",
     "signaturePreview": "Anteprima Firma",
+    "signature2Preview": "Anteprima Firma Chiara",
     "signature": "Firma",
     "badges": "Badge",
     "fname": "Nome",
@@ -26,35 +27,35 @@
     "limitErr": "È possibile selezionare solo cinque badge"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Utente '{scnId}' non trovato.",
+    "network": "Impossibile raggiungere il servizio della Comunità SAP. Controlla la tua connessione e riprova.",
+    "unexpected": "Si è verificato un errore imprevisto durante il caricamento del profilo.",
+    "retry": "Riprova"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tabella",
+    "grid": "Griglia"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "Solo URL",
+    "copy": "Copia",
+    "copied": "Copiato",
+    "copyFallback": "Selezionato — premi Ctrl+C per copiare"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "Firma della Comunità SAP di {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Anteprima",
+    "expand": "Mostra firma",
+    "collapse": "Nascondi firma"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Cambia tema",
+    "light": "Tema: chiaro (clicca per scuro)",
+    "dark": "Tema: scuro (clicca per automatico)",
+    "auto": "Tema: automatico — segue il sistema (clicca per chiaro)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/iw.json
+++ b/srv/app/profile-vue/src/i18n/locales/iw.json
@@ -11,6 +11,7 @@
     "url": "כתובת URL של הפרופיל",
     "Toolbar2": "חתימה",
     "signaturePreview": "תצוגה מקדימה של החתימה",
+    "signature2Preview": "תצוגה מקדימה של חתימה בהירה",
     "signature": "חתימה",
     "badges": "תגים",
     "fname": "שם פרטי",
@@ -26,35 +27,35 @@
     "limitErr": "ניתן לבחור עד חמישה תגים בלבד"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "המשתמש '{scnId}' לא נמצא.",
+    "network": "לא ניתן להגיע לשירות קהילת SAP. בדוק את החיבור שלך ונסה שוב.",
+    "unexpected": "אירעה שגיאה בלתי צפויה בעת טעינת הפרופיל.",
+    "retry": "נסה שוב"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "טבלה",
+    "grid": "רשת"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "רק כתובת URL",
+    "copy": "העתק",
+    "copied": "הועתק",
+    "copyFallback": "נבחר — לחץ Ctrl+C להעתקה"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "חתימת קהילת SAP של {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "תצוגה מקדימה",
+    "expand": "הצג חתימה",
+    "collapse": "הסתר חתימה"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "החלף ערכת נושא",
+    "light": "ערכת נושא: בהיר (לחץ עבור כהה)",
+    "dark": "ערכת נושא: כהה (לחץ עבור אוטומטי)",
+    "auto": "ערכת נושא: אוטומטי — בהתאם למערכת (לחץ עבור בהיר)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/ja.json
+++ b/srv/app/profile-vue/src/i18n/locales/ja.json
@@ -11,6 +11,7 @@
     "url": "プロファイルURL",
     "Toolbar2": "署名",
     "signaturePreview": "署名プレビュー",
+    "signature2Preview": "ライト署名プレビュー",
     "signature": "署名",
     "badges": "バッジ",
     "fname": "名",
@@ -26,35 +27,35 @@
     "limitErr": "バッジは5つまでしか選択できません"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "ユーザー '{scnId}' が見つかりません。",
+    "network": "SAPコミュニティサービスに接続できませんでした。接続を確認して再試行してください。",
+    "unexpected": "プロファイルの読み込み中に予期しないエラーが発生しました。",
+    "retry": "再試行"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "テーブル",
+    "grid": "グリッド"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "URLのみ",
+    "copy": "コピー",
+    "copied": "コピーしました",
+    "copyFallback": "選択済み — Ctrl+Cでコピーしてください"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "{scnId} のSAPコミュニティ署名"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "プレビュー",
+    "expand": "署名を表示",
+    "collapse": "署名を非表示"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "テーマを切り替え",
+    "light": "テーマ: ライト（クリックでダーク）",
+    "dark": "テーマ: ダーク（クリックで自動）",
+    "auto": "テーマ: 自動 — システムに従う（クリックでライト）"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/la.json
+++ b/srv/app/profile-vue/src/i18n/locales/la.json
@@ -11,6 +11,7 @@
     "url": "URL Profili",
     "Toolbar2": "Signatura",
     "signaturePreview": "Praevisum Signaturae",
+    "signature2Preview": "Praevisum Signaturae Lucidae",
     "signature": "Signatura",
     "badges": "Insignia",
     "fname": "Praenomen",
@@ -26,35 +27,35 @@
     "limitErr": "Tantum quinque insignia eligere potes"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Usor '{scnId}' non inventus est.",
+    "network": "Servitium Communitatis SAP attingi non potuit. Connexionem tuam inspice et iterum tenta.",
+    "unexpected": "Aliquid inopinatum accidit dum profilum oneratur.",
+    "retry": "Iterum tenta"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tabula",
+    "grid": "Reticulum"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "URL tantum",
+    "copy": "Transcribe",
+    "copied": "Transcriptum",
+    "copyFallback": "Selectum — preme Ctrl+C ad transcribendum"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "Signatura Communitatis SAP usoris {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Praevisum",
+    "expand": "Signaturam ostende",
+    "collapse": "Signaturam absconde"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Speciem muta",
+    "light": "Species: lucida (preme pro obscura)",
+    "dark": "Species: obscura (preme pro automatica)",
+    "auto": "Species: automatica — systema sequitur (preme pro lucida)"
   }
 }

--- a/srv/app/profile-vue/src/i18n/locales/pl.json
+++ b/srv/app/profile-vue/src/i18n/locales/pl.json
@@ -11,6 +11,7 @@
     "url": "URL Profilu",
     "Toolbar2": "Podpis",
     "signaturePreview": "Podgląd Podpisu",
+    "signature2Preview": "Podgląd Jasnego Podpisu",
     "signature": "Podpis",
     "badges": "Odznaki",
     "fname": "Imię",
@@ -26,35 +27,35 @@
     "limitErr": "Możesz wybrać tylko pięć odznak"
   },
   "error": {
-    "notFound": "User '{scnId}' not found.",
-    "network": "Could not reach the SAP Community service. Check your connection and try again.",
-    "unexpected": "Something unexpected happened while loading the profile.",
-    "retry": "Retry"
+    "notFound": "Użytkownik '{scnId}' nie został znaleziony.",
+    "network": "Nie można nawiązać połączenia z usługą Społeczności SAP. Sprawdź swoje połączenie i spróbuj ponownie.",
+    "unexpected": "Wystąpił nieoczekiwany błąd podczas ładowania profilu.",
+    "retry": "Spróbuj ponownie"
   },
   "view": {
-    "table": "Table",
-    "grid": "Grid"
+    "table": "Tabela",
+    "grid": "Siatka"
   },
   "embed": {
     "html": "HTML",
     "markdown": "Markdown",
-    "url": "URL only",
-    "copy": "Copy",
-    "copied": "Copied",
-    "copyFallback": "Selected — press Ctrl+C to copy"
+    "url": "Tylko URL",
+    "copy": "Kopiuj",
+    "copied": "Skopiowano",
+    "copyFallback": "Zaznaczono — naciśnij Ctrl+C, aby skopiować"
   },
   "signature": {
-    "alt": "{scnId} SAP Community signature"
+    "alt": "Podpis Społeczności SAP użytkownika {scnId}"
   },
   "mobile": {
-    "preview": "Preview",
-    "expand": "Show signature",
-    "collapse": "Hide signature"
+    "preview": "Podgląd",
+    "expand": "Pokaż podpis",
+    "collapse": "Ukryj podpis"
   },
   "theme": {
-    "toggle": "Toggle theme",
-    "light": "Theme: light (click for dark)",
-    "dark": "Theme: dark (click for auto)",
-    "auto": "Theme: auto — follows OS (click for light)"
+    "toggle": "Przełącz motyw",
+    "light": "Motyw: jasny (kliknij dla ciemnego)",
+    "dark": "Motyw: ciemny (kliknij dla automatycznego)",
+    "auto": "Motyw: automatyczny — zgodny z systemem (kliknij dla jasnego)"
   }
 }


### PR DESCRIPTION
## Summary

Closes #34.

The error/view/embed/signature/mobile/theme keys added in PRs #25/#27/#28 had English fallbacks in all 10 non-English locale files. `vue-i18n.fallbackLocale` meant nothing was broken, but native speakers saw English mixed with their otherwise-translated UI. Now translated.

Bonus: the `profile.signature2Preview` key was also missing from all 10 non-English locales (added in PR #25 but never back-filled). Added everywhere with localized values.

## Locales translated

| Locale | Notes |
|---|---|
| de | German |
| es | Spanish |
| fr | French |
| hi | Hindi |
| it | Italian |
| iw | Hebrew |
| ja | Japanese |
| pl | Polish |
| la | Latin — period-appropriate flavor (`Praevisum`, `Speciem muta`, `Tabula` / `Reticulum`) |
| i-klingon | Easter egg — Klingon vocabulary (`qaStaH nuq`, `Qapla'`, `wIv`, `choH`, `yIqIp`, `So'moH`, `'angmoH`) mixed with English where uncertain, matching the existing partial-translation pattern of that file |

## Translator note

These were drafted with basic linguistic knowledge, not by native speakers. **Translation quality is best-effort**, especially for hi/iw/ja/pl/la/i-klingon. Native speakers should feel free to refine any specific phrasing — subsequent edits to these JSON files don't require any code changes.

## Verification

- `npm test` → 67 passed (unchanged)
- `npm run build` → clean (vue-i18n's JSON parser would fail the build on any syntax error in the locale files)

## No version bump

Translation-only change. The deployed artifact's behavior is identical for English users; non-English users see localized strings instead of English fallbacks. Could be deployed alongside the next other change, no need for an MTAR rebuild on its own.