### PR TITLE
fix: tab panes invisible + overload-protection 503 storms (closes #46 #47 #48)

### DIFF
--- a/srv/app/profile-vue/src/components/SignatureRail.vue
+++ b/srv/app/profile-vue/src/components/SignatureRail.vue
@@ -75,7 +75,6 @@ function handleImgError(e: Event) {
 
     <ui5-tabcontainer
       class="sig-rail__tabs"
-      collapsed
       tabs-overflow-mode="End"
       @tab-select="onTabSelect"
     >

--- a/srv/server/overloadProtection.js
+++ b/srv/server/overloadProtection.js
@@ -7,12 +7,29 @@ module.exports = (app) => {
         maxEventLoopDelay: 100, // maximum detected delay between event loop ticks [default 42]
         maxHeapUsedBytes: 0, // maximum heap used threshold (0 to disable) [default 0]
         maxRssBytes: 0, // maximum rss size threshold (0 to disable) [default 0]
-        errorPropagationMode: false, // dictate behavior: take over the response 
+        errorPropagationMode: false, // dictate behavior: take over the response
         logging: (message)=>{
             app.logger.error(message)
         }
         // or propagate an error to the framework [default false]
     }
     const protect = require('overload-protection')('express', protectCfg)
-    app.use(protect)
+
+    /**
+     * Skip overload-protection for static-asset routes (Vue SPA chunks, FLP
+     * SAPUI5 assets, images, favicons). A cold-cache page load fires 30+
+     * simultaneous static requests; serving them is cheap, but the burst
+     * pushes the event loop past maxEventLoopDelay and the middleware sheds
+     * subsequent requests as 503s — including the dynamically-imported UI5
+     * chunks, which don't auto-retry. The result is a partially-broken UI
+     * on first load.
+     *
+     * Keep the protection on dynamic routes (/khoros/*, /showcase*, etc.)
+     * which actually do real work and benefit from shedding under load.
+     */
+    const STATIC_PATHS = /^\/(profile\/(assets|.*\.(?:js|css|svg|png|jpg|jpeg|ico|woff2?|ttf|map))|flp|images|favicon\.ico|i18n)/
+    app.use((req, res, next) => {
+        if (STATIC_PATHS.test(req.path)) return next()
+        return protect(req, res, next)
+    })
 }


### PR DESCRIPTION
## Summary

Three real issues found during in-browser triage of post-deploy main, all small and related enough to fix together.

## #46 — Tab panes invisible

The `<ui5-tabcontainer collapsed>` attribute I added in PR #44 means **permanently collapsed**, not 'initially collapsed' (my misreading of the API). Result: HTML / Markdown / URL tab labels rendered but the `<pre>` embed-code panes were never shown.

**Fix:** drop the attribute. Tab content now displays correctly.

| Before | After |
|---|---|
| Just three tab labels, no body | Tabs + embed code visible (verified via screenshot) |

## #47 + #48 — overload-protection 503 storms on cold-cache loads

A fresh `/profile/<scnId>` load fires ~30 simultaneous static-asset requests (Vue chunks, UI5 fonts, parameters-bundle.css-*.js dynamic imports, etc.). The burst pushes the event loop past the `maxEventLoopDelay: 100ms` threshold; `overload-protection` then sheds subsequent requests as 503s — including:
- Dynamically-imported UI5 chunks (don't auto-retry → permanent breakage in that session)
- The `/showcaseBadgesGroups/*` and `/showcaseSingleBadge/*` signature image endpoints (broken-image icons in the rail)

**Fix:** skip overload-protection for static-asset paths. They're cheap to serve and don't deserve shedding — they were the very thing TRIGGERING the load. Keep the protection on dynamic API routes which actually do work.

```js
const STATIC_PATHS = /^\/(profile\/(assets|.*\.(?:js|css|svg|png|jpg|jpeg|ico|woff2?|ttf|map))|flp|images|favicon\.ico|i18n)/
app.use((req, res, next) => {
  if (STATIC_PATHS.test(req.path)) return next()
  return protect(req, res, next)
})
```

The regex covers Vue chunks, FLP SAPUI5 assets, fonts, images, favicon, and i18n bundles.

## Verification

End-to-end via Chrome DevTools on a fresh `npm run build` + Express start:

| Metric | Before | After |
|---|---|---|
| Console errors on cold-cache reload | 7 (5×503 + 2 module-fetch failures) | **0** |
| `GET /profile/139` | 200 | 200 |
| Asset 503s | 5+ during burst | 0 |
| Visible tab panes | 0 (regression from #44) | All 3 work |
| Signature image | broken-image icon (503'd) | renders correctly |

Tests: 67/67 unit. Build: clean.

## Should this be a 5.4.4 deploy?

**Yes — recommend deploying.** #46 is a user-visible regression (the embed code panes were silently broken in prod since #44 merged this morning). #47/#48 are intermittent but real on cold-cache loads. Patch bump 5.4.3 → 5.4.4 per CLAUDE.md sync rule.