### PR TITLE
ci: run Vue unit + Playwright e2e tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,42 @@ jobs:
       - name: Install MTA Build Tool
         run: npm install -g mbt
 
-      - name: Install dependencies
+      - name: Install Express dependencies
         run: npm ci
         working-directory: srv
 
-      - name: Lint
+      - name: Install Vue SPA dependencies
+        run: npm ci
+        working-directory: srv/app/profile-vue
+
+      - name: Lint Express
         run: npx eslint .
         working-directory: srv
+
+      - name: Vue unit tests (Vitest)
+        run: npm test
+        working-directory: srv/app/profile-vue
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: srv/app/profile-vue
+
+      - name: Vue end-to-end tests (Playwright)
+        run: npm run test:e2e
+        working-directory: srv/app/profile-vue
+        env:
+          # Playwright's webServer runs `npm --prefix ../.. run build:vue && npm --prefix ../.. start`,
+          # which builds the SPA and boots Express. CI=true tells Playwright not to
+          # reuse an existing server (we want a fresh one).
+          CI: 'true'
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: srv/app/profile-vue/playwright-report/
+          retention-days: 7
 
       - name: Validate MTA build
         run: mbt build --mtar archive


### PR DESCRIPTION
## Summary

The Vue app at `srv/app/profile-vue/` had **zero CI coverage** before this PR. `ci.yml` ran lint + MTA-build-validation but never executed any tests — which is exactly how PR #28 (the blank `/profile` page from a Vue Router base-path mistake) shipped to prod without being caught.

This PR fixes that gap.

## What CI now does on every PR

1. **Install Vue SPA deps** (`npm ci` in `srv/app/profile-vue`)
2. **Lint Express** (existing, unchanged)
3. **Run vitest unit tests** (currently 67 cases covering pure utils, Pinia store, composables, and component smoke tests)
4. **Install Playwright Chromium** with `--with-deps` (Linux runners have system libs)
5. **Run Playwright e2e** (currently 2 tests: happy-path with mocked Khoros + not-found banner)
6. **Upload Playwright report on failure** — videos and traces are downloadable from the GitHub UI for any failed PR
7. **Validate MTA build** (existing, unchanged; runs last because the Vue dist is built as a side effect of the e2e webServer)

## Order is fast-fail

Unit tests (~5s) run **before** Playwright install (~30s download + setup) so a unit failure doesn't waste time on the e2e step.

## CI runtime impact

Estimated ~1.5–2 min added per PR:
- Vue deps install: ~30s
- Vitest: ~5s
- Playwright install: ~30s
- E2E run: ~50s

Acceptable trade-off for the regression safety net.

## Verification

The workflow YAML validates as parseable:

```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
valid YAML
```

This PR opening will itself trigger CI, so we'll see a real run before merging — if the Playwright step has any environment surprises, we'll catch them on this PR's first CI cycle.

## Future enhancements (not in this PR)

- Cache `~/.cache/ms-playwright/` to skip the Chromium download on repeat runs (saves ~30s/PR).
- Run vitest with coverage and post a comment on PRs.
- Add the production-build sanity check (HTML/asset URL routing) as a separate, fast e2e case.