### PR TITLE
chore(profile-vue): codebase hygiene pass

### DIFF
--- a/srv/app/profile-vue/.gitignore
+++ b/srv/app/profile-vue/.gitignore
@@ -1,11 +1,14 @@
 node_modules
 dist
 .vite
+.tsbuild
 *.tsbuildinfo
 test-results
 playwright-report
 
-# vue-tsc -b emit artifacts (Vite handles real emit; tsc is for type-checking only)
+# vue-tsc -b emit artifacts (Vite handles real emit; tsc is for type-checking only).
+# tsconfig.json now sets noEmit:true so future builds shouldn't produce these.
+# Ignored anyway as a safety net for stale files from previous builds.
 src/**/*.js
 src/**/*.d.ts
 !src/types/*.d.ts

--- a/srv/app/profile-vue/src/i18n/index.ts
+++ b/srv/app/profile-vue/src/i18n/index.ts
@@ -16,24 +16,23 @@ export const SUPPORTED_LOCALES = [
 ] as const
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 
+/** True when `code` is one of the locales we ship messages for. */
+export function isSupportedLocale(code: string): code is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(code)
+}
+
 const STORAGE_KEY = 'profileLocale'
 
 function detectInitialLocale(): SupportedLocale {
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
-    if (saved && SUPPORTED_LOCALES.includes(saved as SupportedLocale)) {
-      return saved as SupportedLocale
-    }
+    if (saved && isSupportedLocale(saved)) return saved
   } catch { /* localStorage unavailable; fall through */ }
   const browser = (typeof navigator !== 'undefined' ? navigator.language : 'en').toLowerCase()
   // Match exact codes first (e.g. 'i-klingon'), then primary subtag.
-  if (SUPPORTED_LOCALES.includes(browser as SupportedLocale)) {
-    return browser as SupportedLocale
-  }
+  if (isSupportedLocale(browser)) return browser
   const primary = browser.split('-')[0]
-  if (SUPPORTED_LOCALES.includes(primary as SupportedLocale)) {
-    return primary as SupportedLocale
-  }
+  if (isSupportedLocale(primary)) return primary
   return 'en'
 }
 
@@ -48,8 +47,25 @@ export const i18n = createI18n({
   }
 })
 
-export function setLocale(locale: SupportedLocale): void {
-  ;(i18n.global.locale as unknown as { value: SupportedLocale }).value = locale
+/**
+ * Set the active locale. No-op for unsupported codes.
+ *
+ * vue-i18n v10's Composition API types `i18n.global.locale` as a
+ * `WritableComputedRef<string>` whose `.value` is `string` — but mutating it
+ * is supported and is the documented way to switch locale at runtime. The
+ * single-property cast below narrows the type to what we actually use without
+ * resorting to `as unknown` or `as never`.
+ */
+export function setLocale(locale: string): void {
+  if (!isSupportedLocale(locale)) return
+  const ref = i18n.global.locale as { value: SupportedLocale }
+  ref.value = locale
   document.documentElement.setAttribute('lang', locale)
   try { localStorage.setItem(STORAGE_KEY, locale) } catch { /* ignore */ }
+}
+
+/** Read the current locale (typed). */
+export function currentLocale(): SupportedLocale {
+  const value = (i18n.global.locale as { value: string }).value
+  return isSupportedLocale(value) ? value : 'en'
 }

--- a/srv/app/profile-vue/src/main.ts
+++ b/srv/app/profile-vue/src/main.ts
@@ -44,7 +44,9 @@ import { applyTheme, resolveTheme, watchOsTheme } from './theme'
 
 applyTheme(resolveTheme())
 watchOsTheme()
-setLocale(i18n.global.locale.value as never)
+// Mirror the active locale onto <html lang> + localStorage. setLocale() validates
+// the input and ignores unsupported codes, so passing the raw string is safe.
+setLocale(i18n.global.locale.value)
 
 const app = createApp(App)
 app.use(createPinia())

--- a/srv/app/profile-vue/tsconfig.json
+++ b/srv/app/profile-vue/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "types": ["vite/client", "vitest/globals"],
     "baseUrl": ".",
-    "paths": { "@/*": ["src/*"] }
+    "paths": { "@/*": ["src/*"] },
+    "noEmit": true
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["tests/e2e/**"],

--- a/srv/app/profile-vue/tsconfig.node.json
+++ b/srv/app/profile-vue/tsconfig.node.json
@@ -4,7 +4,10 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "emitDeclarationOnly": true,
+    "declarationDir": ".tsbuild",
+    "tsBuildInfoFile": ".tsbuild/tsconfig.node.tsbuildinfo"
   },
   "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "tests/e2e/**/*.ts"]
 }

--- a/srv/app/profile-vue/vite.config.ts
+++ b/srv/app/profile-vue/vite.config.ts
@@ -28,6 +28,15 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    emptyOutDir: true
+    emptyOutDir: true,
+    // Default Vite warns at 500 kB. Our main chunk is ~910 kB raw (~220 kB
+    // gzipped) and consists almost entirely of @ui5/webcomponents code —
+    // Select, TabContainer, Table, Avatar, Dialog, Toast, et al. all in one
+    // chunk because they share base classes and tree-shaking can't separate
+    // them. Issue #36 measured that the Assets-fetch.js alternative saves
+    // only ~4 kB raw, so there's no easy split. Threshold bumped to silence
+    // the noise; revisit if a future feature pulls in significantly more
+    // weight (e.g. AnalyticalTable, full Fiori page templates, charts).
+    chunkSizeWarningLimit: 1000
   }
 })


### PR DESCRIPTION
## Summary

Three small cleanups, none user-visible, all reduce future friction.

## 1. Stop vue-tsc from emitting .js / .d.ts artifacts to source

`tsconfig.json` sets `noEmit: true` so type-checking runs but no files are emitted (Vite handles real builds). `tsconfig.node.json` keeps `composite: true` (required for project references) but adds `emitDeclarationOnly` + `declarationDir: '.tsbuild'` so its outputs go somewhere ignored.

Before: every `npm run build` left ~38 stale `.js` files scattered in `src/` and `tests/` — gitignored but a constant `git status` noise source.

**More importantly,** a stale `vite.config.js` was being loaded *preferentially* over `vite.config.ts` because Vite resolves `.js` first. Discovered while debugging the chunk-size warning fix below — my changes to `vite.config.ts` were silently ignored. The `noEmit` change makes this footgun impossible to recreate.

## 2. Remove `as never` / `as unknown` type casts in i18n

Replaced the bare casts with an `isSupportedLocale` type guard:

```ts
// Before
setLocale(i18n.global.locale.value as never)
;(i18n.global.locale as unknown as { value: SupportedLocale }).value = locale

// After
setLocale(i18n.global.locale.value)  // signature accepts string, narrows via guard

export function isSupportedLocale(code: string): code is SupportedLocale {
  return (SUPPORTED_LOCALES as readonly string[]).includes(code)
}
```

`setLocale()` now no-ops on unsupported codes — safer than the cast and clearer to read. Also added `currentLocale()` (typed) for symmetry.

## 3. Silence the chunk-size warning

The main bundle is ~910 kB raw (~220 kB gzipped) — almost entirely `@ui5/webcomponents`. Issue #36 already measured that the `Assets-fetch.js` alternative saves only ~4 kB raw, so there's no easy split. Bumped `chunkSizeWarningLimit` from 500 to 1000 with a comment explaining why.

## Verification

- `npm test` → 67/67 pass
- `npm run build` → clean, no chunk-size warning
- After build, `git status` clean (no stale `.js` artifacts emitted)

## No version bump

Pure tooling/typing cleanup. No production behavior change. Roll into next deployable PR.