### PR TITLE
chore(ci): comment-only header to verify CI runs end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI
+# Runs on every PR to main. Lints + tests Express, builds + tests the Vue SPA
+# (vitest + Playwright e2e), and validates the MTA build. See PR #50 for
+# rationale (Vue tests were absent from CI before, which let PR #28 ship a
+# blank-page regression to prod).
 
 on:
   pull_request:


### PR DESCRIPTION
## Purpose

Verify that the new CI pipeline added in #50 actually runs end-to-end on a PR. This is a comment-only change — 4 lines of header documentation in `.github/workflows/ci.yml`. Will be **closed** (not merged) once the CI run completes successfully.

## What this proves

When this PR's CI job goes green, we know:

1. `actions/checkout@v4` and `actions/setup-node@v4` work as expected on the runner.
2. `npm ci` succeeds in both `srv/` and `srv/app/profile-vue/`.
3. ESLint passes on `srv/`.
4. Vitest's 67 unit tests pass in CI (they pass locally).
5. `npx playwright install --with-deps chromium` works on the Linux runner with the bundled lock file.
6. The 2 e2e tests pass in CI (they require Express to start, which requires the Vue dist to be built — chained via Playwright's `webServer.command`).
7. `mbt build --mtar archive` validates the MTA build without errors.

If any of those steps fails, we'll find out exactly where on the first run rather than discovering it next time someone opens a real PR.

## After verification

This PR will be **closed without merging** — the comment is genuinely useful but not worth a merge commit on its own.

## No version bump

Comment-only change. No deploy needed regardless of outcome.