### PR TITLE
chore: bump version to 5.4.4

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -1,6 +1,6 @@
 _schema-version: "3.3"
 ID: scn-badges
-version: 5.4.3
+version: 5.4.4
 modules:
   - name: scn-badges-srv
     type: nodejs

--- a/srv/package-lock.json
+++ b/srv/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scn-badges-srv",
-      "version": "5.4.3",
+      "version": "5.4.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cloudnative/health-connect": "^2.1.0",

--- a/srv/package.json
+++ b/srv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scn-badges-srv",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "SCN Badges Service Layer",
   "engines": {
     "node": "^22.0.0 || ^24.0.0"


### PR DESCRIPTION
## Summary

Patch bump for everything merged since 5.4.3 deployed earlier today.

## What ships in 5.4.4

| PR | Visible to users? | Notes |
|---|---|---|
| #42 | ✓ Yes | 10 non-English locales now have proper translations for the new error/embed/theme/mobile keys (was English fallback) |
| #43 | ✓ Yes | Locale switcher is now Fiori-styled `<ui5-select>` (was off-theme HTML `<select>`) |
| #44 | ✓ Yes | Embed-code switcher uses native `<ui5-tabcontainer>` |
| #45 | ✓ Yes | Badge picker uses `<ui5-table>` with proper Fiori styling, mobile auto-collapse |
| **#49** | **✓ Yes — regression fix** | **Tab panes were silently invisible after 5.4.3's morning deploy** (`<ui5-tabcontainer collapsed>` API misread); also fixes overload-protection 503 storms on cold-cache loads |
| #50 | No (CI-only) | Vue unit + Playwright e2e tests now run on every PR |
| #51 | No (tooling) | `noEmit:true` stops vue-tsc from leaking artifacts; type-cast cleanup; chunk-size warning silenced |

## Why this should deploy promptly

PR #49 is the most important: the embed-code panes (HTML / Markdown / URL) under the live signature preview have been **invisible since 5.4.3 deployed this morning**. Users see the tab labels but no body. Triaged via Chrome DevTools earlier today and fixed with a one-attribute removal — but it's currently in main and not in prod.

## MTAR

Built at `mta_archives/scn-badges_5.4.4.mtar` (197 MB, ~55 KB larger than 5.4.3 due to the new UI5 components — Select / TabContainer / Table — added in PRs #43/#44/#45).

## Deploy command

After merging this PR:

```bash
cf deploy mta_archives/scn-badges_5.4.4.mtar
```

Or trigger the `Deploy to Cloud Foundry` workflow with version label `5.4.4`.